### PR TITLE
Update ja/GUIDE.md

### DIFF
--- a/resources/langs/ja/GUIDE.md
+++ b/resources/langs/ja/GUIDE.md
@@ -6,7 +6,7 @@ These supplement the common rules; follow the existing translated strings as the
 
 Use the **polite (desu/masu) form** for full sentences — the UI convention in Japanese software. For button labels and short commands, drop sentence-final politeness and use noun phrases or the plain stem (する, 削除, 保存).
 
-- "Failed to join room: %1" → "部屋に参加できませんでした: %1"
+- "Failed to join room: %1" → "ルームに参加できませんでした: %1"
 - "Send" (button) → "送信"
 - "Save" (button) → "保存"
 
@@ -14,17 +14,19 @@ Use the **polite (desu/masu) form** for full sentences — the UI convention in 
 
 | English | Japanese |
 |---|---|
-| room | **部屋** (へや) |
+| room | **ルーム** |
 | space | **スペース** |
 | thread | **スレッド** |
 | direct message, DM | **ダイレクトメッセージ** |
 | invite (verb / noun) | **招待する** / **招待** |
+| invited | **招待済** |
 | join (a room) | **参加する** |
 | leave (a room) | **退出する** |
 | redact (= delete a message) | **削除する** |
+| decrypt | **復号** |
 | encryption | **暗号化** |
-| encrypted | **暗号化された** |
-| verify / verification / verified (E2EE) | **検証する** / **検証** / **検証済み** |
+| encrypted | **暗号化済** |
+| verify / verification / verified (E2EE) | **検証する** / **検証** / **検証済** |
 | user | **ユーザー** |
 | message | **メッセージ** |
 | device | **デバイス** |
@@ -33,6 +35,6 @@ Use the **polite (desu/masu) form** for full sentences — the UI convention in 
 
 - Use **full-width Japanese punctuation**: `、。！？：（）` — not ASCII.
 - Use **「」** for quoted text (Japanese corner brackets).
-- The existing translations use a regular ASCII colon `:` before values (`"部屋に参加できませんでした: %1"`). Keep that convention for consistency unless the source uses a full-width `：`.
+- The existing translations use a regular ASCII colon `:` before values (`"ルームに参加できませんでした: %1"`). Keep that convention for consistency unless the source uses a full-width `：`.
 - Use `…` (U+2026) for ellipsis, not `...`.
 - Avoid unnecessary spaces between Japanese characters and placeholders.


### PR DESCRIPTION
On other clients like Element the "room" is always translated (by me, actually) into "ルーム" in the same way as the space would not be translated into "空間" (the proper pair would be "ルーム and スペース" and "部屋 and 空間").

Also "み" as a suffix is often dropped from the translated strings (not "検証済み" but "検証済", not "招待済み" but "招待済"). "Decrypted" should mostly be translated into "復号" not "復号化".