### PR TITLE
feat(macos): make the native build work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,8 @@ set(
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard")
 set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE BOOL "Require C++ standard to be supported")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "compile as PIC by default")
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "macos deployment target")
+# std::format with float/double pulls in libc++'s to_chars(long double), which Apple marks __builtin_available(macos 13.3); the prior 10.15 default broke every native macOS build with "'to_chars' is unavailable" inside std::format instantiations.
+set(CMAKE_OSX_DEPLOYMENT_TARGET "13.3" CACHE STRING "macos deployment target")
 
 include(cmake/CPM.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1466,6 +1466,8 @@ endif()
 if(APPLE)
     # CoreServices for Launch Services API (external media player lookup by MIME type)
     target_link_libraries(komai PRIVATE "-framework CoreServices")
+    # SystemConfiguration is needed by the `system_configuration` Rust crate (transitive via rustls-platform-verifier); its `cargo:rustc-link-lib=framework=` directive doesn't reach the C++ link line through Corrosion, mirroring the Windows `iphlpapi` workaround below.
+    target_link_libraries(komai PRIVATE "-framework SystemConfiguration")
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -873,9 +873,9 @@ qt_add_resources(QRC resources/res.qrc)
 
 if(APPLE)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework Foundation -framework Cocoa -framework UserNotifications")
-    set(SRC_FILES ${SRC_FILES} src/notifications/NotificationManagerProxy.h src/notifications/MacNotificationDelegate.h src/notifications/MacNotificationDelegate.mm src/notifications/ManagerMac.mm src/notifications/ManagerMac.cpp)
+    set(SRC_FILES ${SRC_FILES} src/notifications/NotificationManagerProxy.h src/notifications/MacNotificationDelegate.h src/notifications/MacNotificationDelegate.mm src/notifications/ManagerMac.mm src/notifications/ManagerMac.cpp src/notifications/MacReopenHandler.h src/notifications/MacReopenHandler.mm)
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
-        set_source_files_properties( src/notifications/NotificationManagerProxy.h src/notifications/MacNotificationDelegate.h src/notifications/MacNotificationDelegate.mm src/notifications/ManagerMac.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+        set_source_files_properties( src/notifications/NotificationManagerProxy.h src/notifications/MacNotificationDelegate.h src/notifications/MacNotificationDelegate.mm src/notifications/ManagerMac.mm src/notifications/MacReopenHandler.h src/notifications/MacReopenHandler.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
     endif()
 elseif(WIN32)
     CPMAddPackage(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1513,10 +1513,14 @@ if(APPLE)
         install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/komai-mcp${CMAKE_EXECUTABLE_SUFFIX}"
             DESTINATION ${CMAKE_INSTALL_BINDIR})
     endif()
+    # Default empty so a normal `just build` on a developer Mac gets stripped + ad-hoc-signed frameworks from macdeployqt.
+    # Packagers can override (e.g. `-no-strip;-no-codesign`) when the host toolchain's strip or codesign isn't safe to invoke during install; Nix sandboxes need this for LC_DYLD_CHAINED_FIXUPS support and a spawn-codesign env quirk.
+    set(KOMAI_DEPLOY_TOOL_OPTIONS "" CACHE STRING "Extra options forwarded to macdeployqt via DEPLOY_TOOL_OPTIONS")
     qt_generate_deploy_qml_app_script(
         TARGET komai
         OUTPUT_SCRIPT deploy_script
         NO_UNSUPPORTED_PLATFORM_ERROR
+        DEPLOY_TOOL_OPTIONS ${KOMAI_DEPLOY_TOOL_OPTIONS}
     )
     install(SCRIPT ${deploy_script})
 endif()

--- a/bin/build/native.sh
+++ b/bin/build/native.sh
@@ -342,6 +342,14 @@ build_runtime_bundle() {
 	fi
 }
 
+# macOS-only: cmake --install runs macdeployqt to copy Qt frameworks, plugins, and QML modules into the bundle and ad-hoc-sign it. Without it, ${build_dir}/komai.app has no Qt dylibs at runtime and won't launch from Finder.
+bundle_macos_app() {
+	if [[ "$(uname)" != "Darwin" ]]; then
+		return 0
+	fi
+	cmake --install "${build_dir}" --prefix "${build_dir}/dist"
+}
+
 run_test_label() {
 	local label="$1"
 	shift || true
@@ -371,12 +379,14 @@ build)
 		configure_release
 	fi
 	build_runtime_bundle "$@"
+	bundle_macos_app
 	;;
 rebuild)
 	ensure_rust_toolchain
 	rm -rf "${build_dir}"
 	configure_release "$@"
 	build_runtime_bundle
+	bundle_macos_app
 	;;
 test-cpp-unit|test-unit)
 	ensure_rust_toolchain

--- a/docs/maintainers/packaging/native/macos.md
+++ b/docs/maintainers/packaging/native/macos.md
@@ -1,24 +1,19 @@
 # Native build on macOS
 
-> ⚠️ **Untested by maintainers.** Komai has never been built on macOS
-> by the project. The notes below are tentative pointers, not verified
-> instructions. PRs welcome.
-
 For shared reference (dependencies, CMake flags, CPM), see
 [native.md](../native.md).
 
+Verified on Apple Silicon, macOS 26.
+
 ## Prerequisites
 
-- [Qt 6.5+](https://www.qt.io/download) with Base, Declarative,
-  Multimedia, SVG, and Tools modules, **including ICNS imageformat
-  support** (the app bundle icon is generated from
-  `resources/komai.svg` at build time).
+- macOS 13.3 or newer. Earlier versions don't ship a libc++ with the floating-point overloads of `std::to_chars`, which Komai uses through `std::format`.
+- [Qt 6.5+](https://www.qt.io/download) with Base, Declarative, Multimedia, SVG, and Tools modules. Both Homebrew (`brew install qt`) and the Qt online installer are known to work.
 - [Python 3](https://www.python.org/downloads/) on `PATH`.
-- [Rust](https://rustup.rs/) -- `rustup` reads
-  [`rust-toolchain.toml`](../../../../rust-toolchain.toml) and picks
-  the pinned version.
+- [Rust](https://rustup.rs/) — `rustup` reads [`rust-toolchain.toml`](../../../../rust-toolchain.toml) and picks the pinned version.
 - Xcode 14+ or a recent Apple Clang from Command Line Tools.
 - CMake 3.15+.
+- [`just`](https://github.com/casey/just) (`brew install just`) — optional but recommended; the rest of this guide drives the build through it.
 
 ## Get the source
 
@@ -26,35 +21,51 @@ For shared reference (dependencies, CMake flags, CPM), see
 git clone https://github.com/etkecc/komai && cd komai
 ```
 
-## Configure and build
+## Build
 
 ```sh
-cmake -S. -Bvar/build/native -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_PREFIX_PATH=$HOME/Qt/<QT_VER>/macos
-cmake --build var/build/native --parallel $(sysctl -n hw.ncpu)
+just build
 ```
 
-Adjust `-DCMAKE_PREFIX_PATH` to wherever the Qt installer placed Qt.
+On macOS this configures (if needed), compiles, runs `cmake --install` into a project-local prefix, and invokes `macdeployqt` so the output is a self-contained `.app`. The result is at:
+
+```
+var/build/native/dist/komai.app
+```
+
+Launch it from Finder, or:
+
+```sh
+open var/build/native/dist/komai.app
+```
+
+If `cmake` can't find Qt automatically (typical with the Qt online installer), point it at your install once with `just configure`:
+
+```sh
+just configure -DCMAKE_PREFIX_PATH=$HOME/Qt/<QT_VER>/macos
+just build
+```
 
 ## VOIP
 
-GStreamer is available on Homebrew but untested here -- start with
-`-DVOIP=OFF`, then add it later:
+Disabled by default on macOS. GStreamer is available on Homebrew but the integration is unverified there. To experiment:
 
 ```sh
 brew install gstreamer gst-plugins-base gst-plugins-good \
     gst-plugins-bad gst-plugins-ugly
+just configure -DVOIP=ON
+just build
 ```
+
+## Packaging notes
+
+- `macdeployqt`'s default strip + ad-hoc codesign passes run automatically during `just build`. To suppress them (for example, when the host toolchain's `strip` doesn't understand modern Mach-O load commands, or when the codesign step runs in a sandbox that can't reach `/usr/bin/codesign`), set `-DKOMAI_DEPLOY_TOOL_OPTIONS=-no-strip;-no-codesign` and handle stripping / signing explicitly after install.
+- The Snap, Flatpak, and AppImage helpers in `etc/packaging/` don't apply on macOS.
 
 ## What's likely to go wrong
 
-- **GStreamer / VOIP.** Build with `-DVOIP=OFF` first.
-- **qtkeychain / KDSingleApplication.** Both build via CPM by default;
-  if CPM fails, install manually and pass `-DCPM_<package>_USE_LOCAL=ON`.
-  KDSingleApplication has had platform-specific bugs historically.
-- **Linux-only packaging helpers.** The Snap, Flatpak, and AppImage
-  build helpers in `etc/packaging/` don't apply -- only the plain
-  CMake flow above does.
+- **CMake can't find Qt.** Set `CMAKE_PREFIX_PATH` to your Qt install root (see above).
+- **VOIP.** Off by default; only turn on once Qt and Komai itself build cleanly.
+- **`just` isn't installed.** Either install it (`brew install just`) or drive the underlying script manually: `bash bin/build/native.sh build`.
 
-If you get a build working, please open an issue or PR with what
-worked so this page can be tightened up.
+If something else trips you up, please open an issue or PR with the symptom and the fix.

--- a/src/app/MainApplication.cpp
+++ b/src/app/MainApplication.cpp
@@ -6,6 +6,14 @@
 #include <iostream>
 #include <optional>
 
+// _exit() is in <process.h> on MSVC and <unistd.h> on POSIX.
+// Linux libstdc++ exposes it transitively through other headers, so Linux/CI builds compile without an explicit include; Apple's libc++ does not.
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 #include <QApplication>
 #include <QCommandLineParser>
 #include <QDesktopServices>

--- a/src/app/MainApplication.cpp
+++ b/src/app/MainApplication.cpp
@@ -58,6 +58,7 @@
 
 #if defined(Q_OS_MACOS)
 #include "notifications/Manager.h"
+#include "notifications/MacReopenHandler.h"
 #endif
 
 #ifdef GSTREAMER_AVAILABLE
@@ -533,6 +534,34 @@ app::runMainApplication(int argc, char *argv[])
     // Need to set up notification delegate so users can respond to messages from within the
     // notification itself.
     NotificationsManager::attachToMacNotifCenter();
+
+    // macOS doesn't bridge "user wants the app's window back" to a show() on its own. The window goes away via MainWindow::closeEvent (close-to-tray) or never appears at all (desktop.system_tray.autostart), and from there:
+    //   - Cmd+Tab away then back fires Qt::ApplicationActive on applicationStateChanged — caught below.
+    //   - Dock-icon click while NSApp is still in the "active, just windowless" state does NOT fire applicationStateChanged (no transition), so we hook AppKit's applicationShouldHandleReopen: directly via MacReopenHandler.
+    // Together the two paths cover every way macOS surfaces "summon the window".
+    auto showMainWindow = [&w] {
+        if (w.isVisible())
+            return;
+        w.show();
+        w.raise();
+        w.requestActivate();
+    };
+    // The reopen handler only fires on an explicit dock-icon click, which is the user's unambiguous "show me the window" signal — fine to always honour.
+    komai::mac::installReopenHandler(showMainWindow);
+    // applicationStateChanged also fires once at launch as the app gains focus, which would override desktop.system_tray.autostart. Gate it on "has the user ever seen the window once" so the launch-time activation can't undo start-in-tray, while Cmd+Tab away → back still triggers a re-show.
+    auto hasBeenVisible = std::make_shared<bool>(false);
+    QObject::connect(&w, &QWindow::visibleChanged, &w, [hasBeenVisible](bool visible) {
+        if (visible)
+            *hasBeenVisible = true;
+    });
+    QObject::connect(
+      &app,
+      &QApplication::applicationStateChanged,
+      &w,
+      [showMainWindow, hasBeenVisible](Qt::ApplicationState state) {
+          if (state == Qt::ApplicationActive && *hasBeenVisible)
+              showMainWindow();
+      });
 #endif
 
     komai::logging::ui()->info("starting komai {}", komai::version);

--- a/src/notifications/MacReopenHandler.h
+++ b/src/notifications/MacReopenHandler.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Komai Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <functional>
+
+namespace komai::mac {
+
+// Wraps NSApp.delegate so a dock-icon click on a running komai with no visible windows reaches us as a Qt-thread callback. macOS surfaces this as NSApplicationDelegate's applicationShouldHandleReopen:hasVisibleWindows: which Qt doesn't translate into any QEvent or signal, so without this wrapper a "start in tray" launch is unreachable from the dock until the user finds the menu-bar item.
+// The wrapper installs itself in front of Qt's existing delegate and forwards every other selector unchanged. Idempotent — only the first call wires anything up.
+void installReopenHandler(std::function<void()> onReopen);
+
+} // namespace komai::mac

--- a/src/notifications/MacReopenHandler.mm
+++ b/src/notifications/MacReopenHandler.mm
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Komai Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#import "notifications/MacReopenHandler.h"
+
+#import <AppKit/NSApplication.h>
+#import <Foundation/Foundation.h>
+
+@interface KomaiReopenHandler : NSObject <NSApplicationDelegate> {
+    std::function<void()> _onReopen;
+}
+@property (nonatomic, strong) id<NSApplicationDelegate> nextDelegate;
+- (instancetype)initWithCallback:(std::function<void()>)onReopen
+                    nextDelegate:(id<NSApplicationDelegate>)next;
+@end
+
+@implementation KomaiReopenHandler
+
+- (instancetype)initWithCallback:(std::function<void()>)onReopen
+                    nextDelegate:(id<NSApplicationDelegate>)next
+{
+    if ((self = [super init])) {
+        _onReopen = std::move(onReopen);
+        _nextDelegate = next;
+    }
+    return self;
+}
+
+// AppKit calls this on the main thread whenever the user clicks the dock icon on a running app; flag is NO when there are no visible windows, which is precisely the case komai needs to react to ("start in tray", or close-to-tray when QApplication::applicationStateChanged didn't fire because the app never went Inactive first).
+- (BOOL)applicationShouldHandleReopen:(NSApplication *)sender hasVisibleWindows:(BOOL)flag
+{
+    if (!flag && _onReopen) {
+        _onReopen();
+    }
+    if ([_nextDelegate respondsToSelector:_cmd]) {
+        return [_nextDelegate applicationShouldHandleReopen:sender hasVisibleWindows:flag];
+    }
+    return YES;
+}
+
+// Forward every other delegate selector to whatever delegate Qt installed, so we don't accidentally swallow notifications, URL-open events, or termination requests by stealing the slot.
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    if ([super respondsToSelector:aSelector])
+        return YES;
+    return [_nextDelegate respondsToSelector:aSelector];
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector
+{
+    if ([_nextDelegate respondsToSelector:aSelector])
+        return _nextDelegate;
+    return nil;
+}
+
+@end
+
+namespace komai::mac {
+
+void
+installReopenHandler(std::function<void()> onReopen)
+{
+    static KomaiReopenHandler *handler = nil;
+    if (handler != nil)
+        return;
+
+    handler = [[KomaiReopenHandler alloc] initWithCallback:std::move(onReopen)
+                                              nextDelegate:NSApp.delegate];
+    NSApp.delegate = handler;
+}
+
+} // namespace komai::mac

--- a/src/providers/ColorImageProvider.cpp
+++ b/src/providers/ColorImageProvider.cpp
@@ -23,6 +23,10 @@ ColorImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &r
     if (args.size() < 2)
         return source;
 
+    // Painting into a null QPixmap dereferences a null QPlatformPixmap inside QPixmap::detach() and segfaults; source can be null when the requested image-format plugin is missing in a packaged build or the QRC path is wrong.
+    if (source.isNull())
+        return source;
+
     QColor color(args[1]);
 
     QPixmap colorized = source;

--- a/src/settings/SettingsStorageSecureBackend.cpp
+++ b/src/settings/SettingsStorageSecureBackend.cpp
@@ -135,6 +135,11 @@ invokeSecureBackendBlocking(Func &&func)
         return failedSecureBackendResult(QStringLiteral("No QCoreApplication instance"));
     }
 
+#ifdef Q_OS_MACOS
+    // qtkeychain's macOS backend dispatches Job::finished completions via the main GCD queue, so hopping to our worker via BlockingQueuedConnection from the main thread deadlocks: main blocks waiting for the worker, the worker spins inside performRead*'s nested QEventLoop waiting for finished, and the completion that would fire finished is itself queued on the (now blocked) main thread.
+    // Running on the caller thread lets the nested QEventLoop pump the dispatch queue directly and the call returns normally.
+    return std::forward<Func>(func)();
+#else
     auto &state    = secureBackendThreadState();
     auto operation = std::forward<Func>(func);
     SecureBackendJobResult result;
@@ -152,6 +157,7 @@ invokeSecureBackendBlocking(Func &&func)
     }
 
     return result;
+#endif
 }
 
 template<typename Func>


### PR DESCRIPTION
## Summary

- Fix five bugs that blocked any first-time native macOS build, all surfaced by actually compiling and running komai on macOS arm64.
- Bridge two platform-specific UX gaps so macOS users get the same flow Linux already has: dock-click / Cmd+Tab reactivation after close-to-tray, and `just build` producing a launchable `.app` bundle in one step.
- Rewrite `docs/maintainers/packaging/native/macos.md` to replace the "untested by maintainers" caveat with the verified procedure.

## Details

- **CMakeLists**: bump `CMAKE_OSX_DEPLOYMENT_TARGET` 10.15 → 13.3 so libc++'s `to_chars(long double)` (required by `std::format` on float/double) is available; link `SystemConfiguration` for the `system_configuration` Rust crate (transitive via rustls-platform-verifier) mirroring the existing Windows `iphlpapi` workaround; expose `KOMAI_DEPLOY_TOOL_OPTIONS` as a cache variable forwarded verbatim to `macdeployqt` for sandboxed packagers that need to suppress strip / codesign.
- **MainApplication.cpp**: include `<unistd.h>` (or `<process.h>` on MSVC) explicitly for `_exit` — Apple's libc++ doesn't pull it in transitively the way Linux libstdc++ does. Wire the new `MacReopenHandler` plus a gated `applicationStateChanged` listener so both dock-click and Cmd+Tab summon the window after close-to-tray, without overriding `desktop.system_tray.autostart` at launch.
- **SettingsStorageSecureBackend.cpp**: skip the worker-thread hop in `invokeSecureBackendBlocking` on macOS. qtkeychain dispatches `Job::finished` via the main GCD queue; the existing `BlockingQueuedConnection` from main to a worker deadlocks because the completion that would fire `finished` is queued on the blocked main thread. Run the operation on the caller thread on macOS; the nested `QEventLoop` pumps the dispatch queue normally.
- **ColorImageProvider.cpp**: return early before constructing `QPainter` when `QPixmap(args[0])` returned a null pixmap (image-format plugin missing in a packaged build, wrong QRC path). The old code dereferences a null `QPlatformPixmap` inside `QPixmap::detach()` and segfaults during QML component construction.
- **MacReopenHandler.{h,mm}**: new thin Objective-C++ delegate that wraps `NSApp.delegate` to forward `applicationShouldHandleReopen:hasVisibleWindows:` to a `std::function<void()>`. Every other selector is forwarded back to whatever delegate Qt installed, so we don't shadow notification or URL-open events.
- **bin/build/native.sh**: add a Darwin-only `bundle_macos_app` step at the tail of `build` and `rebuild` that runs `cmake --install` into `${build_dir}/dist`. `var/build/native/dist/komai.app` is then launchable with `open`.
- **docs**: rewrite the macOS packaging guide for the verified flow (Homebrew or Qt installer, the one-command `just build`, fallback `CMAKE_PREFIX_PATH`, the packaging knob, what's likely to go wrong).

Verified end-to-end on macOS 26 / Apple Silicon: `just build` produces a launchable bundle; keychain probe, profile load, window show / hide, and dock-click reactivation all work.