### PR TITLE
fix: show compact one-line sender tooltip on timeline avatar

### DIFF
--- a/resources/qml/timeline/styles/bubble/TimelineBubbleMessageStyle.qml
+++ b/resources/qml/timeline/styles/bubble/TimelineBubbleMessageStyle.qml
@@ -200,7 +200,7 @@ TimelineMessageStyleBase {
             avatarUserId: wrapper.userId
             avatarRoomId: wrapper.roomIdForColorCoding
             toolTipText: (wrapper.userName.length > 0 && wrapper.userName !== wrapper.userId)
-                ? (wrapper.userName + " (" + wrapper.userId + ")")
+                ? `${wrapper.userName} (${wrapper.userId})`
                 : wrapper.userId
             width: avatarSide
             height: avatarSide

--- a/resources/qml/timeline/styles/bubble/TimelineBubbleMessageStyle.qml
+++ b/resources/qml/timeline/styles/bubble/TimelineBubbleMessageStyle.qml
@@ -199,7 +199,9 @@ TimelineMessageStyleBase {
             avatarUrl: wrapper.avatarImageUrl(wrapper.userId)
             avatarUserId: wrapper.userId
             avatarRoomId: wrapper.roomIdForColorCoding
-            toolTipText: wrapper.userId
+            toolTipText: (wrapper.userName.length > 0 && wrapper.userName !== wrapper.userId)
+                ? (wrapper.userName + " (" + wrapper.userId + ")")
+                : wrapper.userId
             width: avatarSide
             height: avatarSide
 


### PR DESCRIPTION
When `sender_username` is `only_in_large_rooms`, small rooms show only avatars — hovering previously showed just the bare Matrix user ID, with no way to see the display name.

## Change

In `TimelineBubbleMessageStyle.qml`, replace the hardcoded `toolTipText: wrapper.userId` on the `AvatarUserFlipButton` with a compact one-liner:

```qml
toolTipText: (wrapper.userName.length > 0 && wrapper.userName !== wrapper.userId)
    ? `${wrapper.userName} (${wrapper.userId})`
    : wrapper.userId
```

| `wrapper.userName` | `wrapper.userId` | Tooltip |
|---|---|---|
| `Alice` | `@alice:example.org` | `Alice (@alice:example.org)` |
| _(empty)_ | `@alice:example.org` | `@alice:example.org` |
| `@alice:example.org` | `@alice:example.org` | `@alice:example.org` |

`TimelinePlainMessageStyle` is a direct re-export of the bubble style, so both are covered by this single change.