### PR TITLE
Fix videos never playing when proxy streaming fails silently

### DIFF
--- a/resources/qml/dialogs/media/components/ImageOverlayVideoContent.qml
+++ b/resources/qml/dialogs/media/components/ImageOverlayVideoContent.qml
@@ -6,6 +6,7 @@ import QtQuick
 import QtMultimedia
 import QtQuick.Effects
 
+import "../../../ui"
 import "../../../ui/media"
 
 import cc.etke.komai 1.0
@@ -30,6 +31,10 @@ Item {
     readonly property int playbackState: mediaPlayer.playbackState
 
     function togglePlayback() {
+        // A load/download is already in flight — ignore clicks so we don't kick
+        // off duplicate downloads while the spinner is showing.
+        if (mediaPlayer.buffering)
+            return;
         if (!mediaPlayer.loaded)
             mediaPlayer.startDownload();
         else if (mediaPlayer.playbackState === MediaPlayer.PlayingState)
@@ -130,8 +135,9 @@ Item {
 
         readonly property bool hovered: videoHover.hovered
 
-        visible: !videoOutput.visible
-                 || mediaPlayer.playbackState !== MediaPlayer.PlayingState
+        visible: !mediaPlayer.buffering
+                 && (!videoOutput.visible
+                     || mediaPlayer.playbackState !== MediaPlayer.PlayingState)
         anchors.centerIn: parent
         width: Math.max(56, Math.min(parent.width, parent.height) * 0.15)
         height: width
@@ -150,6 +156,16 @@ Item {
             sourceSize.width: width * Screen.devicePixelRatio
             sourceSize.height: height * Screen.devicePixelRatio
         }
+    }
+
+    // Loading indicator shown while the video is being fetched/buffered, so a
+    // click that triggers a download doesn't look like nothing happened.
+    Spinner {
+        anchors.centerIn: parent
+        height: Math.max(48, Math.min(parent.width, parent.height) * 0.12)
+        visible: mediaPlayer.buffering
+        running: visible
+        z: 10
     }
 
     MxcMedia {
@@ -191,6 +207,8 @@ Item {
         mediaState: mediaPlayer.playbackState
         onPositionChanged: mediaPlayer.position = position
         onPlayPauseActivated: {
+            if (mediaPlayer.buffering)
+                return;
             if (mediaPlayer.playbackState == MediaPlayer.PlayingState) {
                 mediaPlayer.pause();
             } else {
@@ -198,7 +216,10 @@ Item {
                 mediaPlayer.play();
             }
         }
-        onLoadActivated: mediaPlayer.startDownload()
+        onLoadActivated: {
+            if (!mediaPlayer.buffering)
+                mediaPlayer.startDownload();
+        }
     }
 
     // HoverHandler for play button hover effect. Pointer handlers are not

--- a/src/ui/MxcMediaProxy.cpp
+++ b/src/ui/MxcMediaProxy.cpp
@@ -67,26 +67,40 @@ MxcMediaProxy::MxcMediaProxy(QObject *parent)
 
                 // When streaming via the proxy fails (e.g. upstream doesn't support Range,
                 // proxy returns 416, QMediaPlayer/FFmpeg can't recover), fall back to
-                // downloading the full file and playing from a local buffer.
-                if (streaming_ && !streamingFallbackAttempted_) {
-                    komai::logging::ui()->info("Streaming failed, falling back to full download");
-                    streamingFallbackAttempted_ = true;
-                    streaming_                  = false;
-                    setRecoveringFromStreamingFallback(true);
-                    stop();
-                    setSource(QUrl());
-                    startDownload(false);
-                }
+                // downloading the full file and playing from a local buffer. If there's
+                // no fallback left, the error is terminal — stop the buffering spinner.
+                if (!fallBackToFullDownload())
+                    setBuffering(false);
             });
     connect(
       this, &MxcMediaProxy::mediaStatusChanged, this, [this](QMediaPlayer::MediaStatus status) {
           komai::logging::ui()->info("Media player status {} and error {}",
                                      static_cast<int>(status),
                                      static_cast<int>(this->error()));
+
+          // The FFmpeg backend does not reliably emit errorOccurred when a streamed
+          // source fails to open — it can silently transition LoadingMedia ->
+          // NoMedia/InvalidMedia with error() still NoError. Treat that as a
+          // streaming failure too so the full-download fallback still kicks in;
+          // otherwise the video stays stuck on its thumbnail forever.
+          if (status == QMediaPlayer::LoadingMedia) {
+              if (streaming_)
+                  streamingLoadStarted_ = true;
+          } else if (status == QMediaPlayer::LoadedMedia || status == QMediaPlayer::BufferedMedia) {
+              // The stream opened successfully; a later NoMedia (end/stop/loop)
+              // is not a load failure and must not trigger the download fallback.
+              streamingLoadStarted_ = false;
+          } else if (streamingLoadStarted_ &&
+                     (status == QMediaPlayer::NoMedia || status == QMediaPlayer::InvalidMedia)) {
+              if (!fallBackToFullDownload())
+                  setBuffering(false);
+          }
       });
     connect(
       this, &MxcMediaProxy::playbackStateChanged, this, [this](QMediaPlayer::PlaybackState status) {
           if (status == QMediaPlayer::PlayingState) {
+              // Frames are flowing now — the load is done, drop the spinner.
+              setBuffering(false);
               pausedAudioOutputReleaseTimer_.stop();
               if (!skipAudioOutput_)
                   createAudioOutputIfNeeded();
@@ -110,6 +124,25 @@ MxcMediaProxy::MxcMediaProxy(QObject *parent)
             &RoomlistModel::currentRoomIdChanged,
             this,
             &MxcMediaProxy::pause);
+}
+
+bool
+MxcMediaProxy::fallBackToFullDownload()
+{
+    // No-op unless we were actively streaming and haven't already fallen back —
+    // this is safe to call from both errorOccurred and mediaStatusChanged.
+    if (!streaming_ || streamingFallbackAttempted_)
+        return false;
+
+    komai::logging::ui()->info("Streaming failed, falling back to full download");
+    streamingFallbackAttempted_ = true;
+    streaming_                  = false;
+    streamingLoadStarted_       = false;
+    setRecoveringFromStreamingFallback(true);
+    stop();
+    setSource(QUrl());
+    startDownload(false); // keeps buffering active through the download
+    return true;
 }
 
 int
@@ -224,6 +257,7 @@ MxcMediaProxy::startDownload(bool onlyCached)
         if (proxyUrl) {
             komai::logging::ui()->info("Streaming media via proxy for event '{}'",
                                        eventId_.toStdString());
+            setBuffering(true);
             streaming_ = true;
             setSource(QUrl(*proxyUrl));
             emit loadedChanged();
@@ -235,9 +269,13 @@ MxcMediaProxy::startDownload(bool onlyCached)
           "Cannot fetch matrix-sdk timeline media for event '{}' without an "
           "active runtime handle",
           eventId_.toStdString());
+        setBuffering(false);
         return;
     }
 
+    // Fetching the full file over the network takes a moment; show a spinner
+    // until playback actually starts.
+    setBuffering(true);
     std::thread([filename, eventId = eventId_, processBuffer, self, handleId]() mutable {
         const auto context = komai::matrix_backend::blockingCallContext();
         QString error;
@@ -254,8 +292,10 @@ MxcMediaProxy::startDownload(bool onlyCached)
            bytes = std::move(bytes),
            error = std::move(error)]() mutable {
               if (!bytes || bytes->isEmpty()) {
-                  if (self)
+                  if (self) {
                       self->setRecoveringFromStreamingFallback(false);
+                      self->setBuffering(false);
+                  }
                   komai::logging::net()->warn(
                     "failed to retrieve active timeline media {} via matrix-sdk runtime: {}",
                     eventId.toStdString(),
@@ -265,8 +305,11 @@ MxcMediaProxy::startDownload(bool onlyCached)
 
               try {
                   QFile file(filename.filePath());
-                  if (!file.open(QIODevice::WriteOnly))
+                  if (!file.open(QIODevice::WriteOnly)) {
+                      if (self)
+                          self->setBuffering(false);
                       return;
+                  }
 
                   file.write(*bytes);
                   file.close();

--- a/src/ui/MxcMediaProxy.h
+++ b/src/ui/MxcMediaProxy.h
@@ -31,6 +31,9 @@ class MxcMediaProxy : public QMediaPlayer
     Q_PROPERTY(bool encrypted READ isEncrypted NOTIFY encryptedChanged)
     Q_PROPERTY(bool recoveringFromStreamingFallback READ recoveringFromStreamingFallback NOTIFY
                  recoveringFromStreamingFallbackChanged)
+    // True while a load/download is in flight but playback hasn't started yet,
+    // so the UI can show a spinner instead of a dead-looking play button.
+    Q_PROPERTY(bool buffering READ buffering NOTIFY bufferingChanged)
     Q_PROPERTY(int orientation READ orientation NOTIFY orientationChanged)
     Q_PROPERTY(float volume READ volume WRITE setVolume NOTIFY volumeChanged)
     Q_PROPERTY(bool muted READ muted WRITE setMuted NOTIFY mutedChanged)
@@ -61,10 +64,13 @@ public:
             buffer.close();
         streaming_                  = false;
         streamingFallbackAttempted_ = false;
+        streamingLoadStarted_       = false;
         setRecoveringFromStreamingFallback(false);
+        setBuffering(false);
     }
 
     bool loaded() const { return buffer.size() > 0 || streaming_; }
+    bool buffering() const { return buffering_; }
     bool isEncrypted() const { return encrypted_; }
     bool recoveringFromStreamingFallback() const { return recoveringFromStreamingFallback_; }
     QString eventId() const { return eventId_; }
@@ -129,6 +135,7 @@ signals:
     void orientationChanged();
     void encryptedChanged();
     void recoveringFromStreamingFallbackChanged();
+    void bufferingChanged();
 
     void volumeChanged();
     void mutedChanged();
@@ -141,12 +148,23 @@ public slots:
 private:
     void createAudioOutputIfNeeded();
     void releaseAudioOutput();
+    // Abandon a failed proxy stream and play from a full local download instead.
+    // Returns true if a fallback download was started; false if there was nothing
+    // to fall back to (not streaming, or already attempted).
+    bool fallBackToFullDownload();
     void setRecoveringFromStreamingFallback(bool recovering)
     {
         if (recoveringFromStreamingFallback_ == recovering)
             return;
         recoveringFromStreamingFallback_ = recovering;
         emit recoveringFromStreamingFallbackChanged();
+    }
+    void setBuffering(bool buffering)
+    {
+        if (buffering_ == buffering)
+            return;
+        buffering_ = buffering;
+        emit bufferingChanged();
     }
 
     QObject *room_ = nullptr;
@@ -160,6 +178,8 @@ private:
     bool encrypted_                       = false;
     bool streaming_                       = false;
     bool streamingFallbackAttempted_      = false;
+    bool streamingLoadStarted_            = false;
     bool recoveringFromStreamingFallback_ = false;
+    bool buffering_                       = false;
     QTimer pausedAudioOutputReleaseTimer_{this};
 };


### PR DESCRIPTION
## Problem
Videos never played on our homeservers — clicking play left the thumbnail up forever.

## Root cause (confirmed with proxy diagnostics)
The overlay streams unencrypted media through the local proxy, with a fallback to a full download when streaming fails. But:
- The homeserver (Synapse) **doesn't support HTTP Range** on media — the proxy logged `status=200 OK, accept_ranges=None`, so it must buffer the whole file before returning anything.
- Phone videos keep their **`moov` atom at the end** — FFmpeg's first read was `bytes=41112286-` (the last ~38 KB), so it needs the entire ~41 MB before it can start.
- While the proxy buffered (~8.7 s), the FFmpeg backend **silently** transitioned `LoadingMedia → NoMedia` with `error() == NoError` — it never emitted `errorOccurred`.
- The existing fallback **only listened for `errorOccurred`**, so it never fired. The player just sat at `NoMedia`.

## Fix
Keep streaming-with-fallback exactly as designed, but also treat that silent `LoadingMedia → NoMedia/InvalidMedia` transition as a streaming failure so the fallback download kicks in. Guarded so it only applies during an actual streaming attempt, and cleared once the stream loads OK (a normal end-of-video `NoMedia` must not re-trigger it).

Plus:
- New `buffering` property on `MxcMediaProxy` drives a **spinner** in the overlay while media loads/downloads (previously a working download looked like a dead button).
- Play controls are **guarded** during buffering so repeat clicks don't spawn duplicate downloads.

No streaming architecture removed — this only makes the fallback catch the failure mode it was missing.

## Testing
- `just build` — clean
- Verified live: video plays (this run the stream itself succeeded after the buffer wait; the guard correctly did **not** trigger a spurious fallback, and end-of-video `NoMedia` didn't either). On timeout runs, the silent-failure fallback downloads and plays. Spinner shows during the wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)