### PR TITLE
Delay unsent composer drafts before they count as attention

### DIFF
--- a/resources/langs/ar/komai_ar.ts
+++ b/resources/langs/ar/komai_ar.ts
@@ -7148,7 +7148,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>أنت</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>دعوة من %1</translation>

--- a/resources/langs/bg/komai_bg.ts
+++ b/resources/langs/bg/komai_bg.ts
@@ -7116,7 +7116,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>Ти</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Покана от %1</translation>

--- a/resources/langs/ca/komai_ca.ts
+++ b/resources/langs/ca/komai_ca.ts
@@ -7116,7 +7116,7 @@ Tingues en compte que no es pot desactivar posteriorment.</translation>
         <translation>Tu</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Convidat per %1</translation>

--- a/resources/langs/cs/komai_cs.ts
+++ b/resources/langs/cs/komai_cs.ts
@@ -7124,7 +7124,7 @@ Berte na vědomí, že po aktivaci jej nelze vypnout.</translation>
         <translation>Vy</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Pozváno od %1</translation>

--- a/resources/langs/de/komai_de.ts
+++ b/resources/langs/de/komai_de.ts
@@ -7116,7 +7116,7 @@ Bitte beachte, dass sie danach nicht mehr deaktiviert werden kann.</translation>
         <translation>Du</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Eingeladen von %1</translation>

--- a/resources/langs/el/komai_el.ts
+++ b/resources/langs/el/komai_el.ts
@@ -7116,7 +7116,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>Εσύ</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Πρόσκληση από %1</translation>

--- a/resources/langs/en/komai_en.ts
+++ b/resources/langs/en/komai_en.ts
@@ -7086,7 +7086,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation type="unfinished"/>

--- a/resources/langs/eo/komai_eo.ts
+++ b/resources/langs/eo/komai_eo.ts
@@ -7118,7 +7118,7 @@ Notu ke ĝi ne povas esti malŝaltita poste.</translation>
         <translation>Vi</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Invitita de %1</translation>

--- a/resources/langs/es/komai_es.ts
+++ b/resources/langs/es/komai_es.ts
@@ -7119,7 +7119,7 @@ Ten en cuenta que no se puede desactivar después.</translation>
         <translation>Tú</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Invitado por %1</translation>

--- a/resources/langs/et/komai_et.ts
+++ b/resources/langs/et/komai_et.ts
@@ -7116,7 +7116,7 @@ Pane tähele, et seda ei saa hiljem keelata.</translation>
         <translation>Sina</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Kutsuja: %1</translation>

--- a/resources/langs/fa/komai_fa.ts
+++ b/resources/langs/fa/komai_fa.ts
@@ -7108,7 +7108,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>شما</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>دعوت‌شده توسط %1</translation>

--- a/resources/langs/fi/komai_fi.ts
+++ b/resources/langs/fi/komai_fi.ts
@@ -7116,7 +7116,7 @@ Huomaa, että sitä ei voi poistaa käytöstä jälkeenpäin.</translation>
         <translation>Sinä</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>%1 kutsui</translation>

--- a/resources/langs/fr/komai_fr.ts
+++ b/resources/langs/fr/komai_fr.ts
@@ -7116,7 +7116,7 @@ Veuillez noter qu'il ne peut pas être désactivé par la suite.</translation>
         <translation>Vous</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Invité par %1</translation>

--- a/resources/langs/hu/komai_hu.ts
+++ b/resources/langs/hu/komai_hu.ts
@@ -7108,7 +7108,7 @@ Kérjük, vegye figyelembe, hogy utólag nem lehet kikapcsolni.</translation>
         <translation>Te</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>%1 hívta meg</translation>

--- a/resources/langs/id/komai_id.ts
+++ b/resources/langs/id/komai_id.ts
@@ -7108,7 +7108,7 @@ Harap diperhatikan bahwa enkripsi tidak dapat dinonaktifkan setelahnya.</transla
         <translation>Anda</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Diundang oleh %1</translation>

--- a/resources/langs/ie/komai_ie.ts
+++ b/resources/langs/ie/komai_ie.ts
@@ -7116,7 +7116,7 @@ Plase notar que it ne posse esser disactivat depos.</translation>
         <translation>Vu</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Invitat par %1</translation>

--- a/resources/langs/it/komai_it.ts
+++ b/resources/langs/it/komai_it.ts
@@ -7116,7 +7116,7 @@ Si noti che non può essere disabilitata in seguito.</translation>
         <translation>Tu</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Invitato da %1</translation>

--- a/resources/langs/ja/komai_ja.ts
+++ b/resources/langs/ja/komai_ja.ts
@@ -7108,7 +7108,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>あなた</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>%1 から招待されました</translation>

--- a/resources/langs/ko/komai_ko.ts
+++ b/resources/langs/ko/komai_ko.ts
@@ -7108,7 +7108,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>나</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>%1에게서 초대됨</translation>

--- a/resources/langs/ml/komai_ml.ts
+++ b/resources/langs/ml/komai_ml.ts
@@ -7116,7 +7116,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>നിങ്ങൾ</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>%1 ക്ഷണിച്ചു</translation>

--- a/resources/langs/nl/komai_nl.ts
+++ b/resources/langs/nl/komai_nl.ts
@@ -7116,7 +7116,7 @@ Let op dat het achteraf niet uitgeschakeld kan worden.</translation>
         <translation>Jij</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Uitgenodigd door %1</translation>

--- a/resources/langs/pl/komai_pl.ts
+++ b/resources/langs/pl/komai_pl.ts
@@ -7125,7 +7125,7 @@ Zwróć uwagę, że nie można go później wyłączyć.</translation>
         <translation>Ty</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Zaproszono przez %1</translation>

--- a/resources/langs/pt_BR/komai_pt_BR.ts
+++ b/resources/langs/pt_BR/komai_pt_BR.ts
@@ -7116,7 +7116,7 @@ Observe que ela não pode ser desativada depois.</translation>
         <translation>Você</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Convidado por %1</translation>

--- a/resources/langs/pt_PT/komai_pt_PT.ts
+++ b/resources/langs/pt_PT/komai_pt_PT.ts
@@ -7116,7 +7116,7 @@ Tenha em atenção que não pode ser desativada posteriormente.</translation>
         <translation>Tu</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Convidado por %1</translation>

--- a/resources/langs/ro/komai_ro.ts
+++ b/resources/langs/ro/komai_ro.ts
@@ -7124,7 +7124,7 @@ Rețineți că nu poate fi dezactivată ulterior.</translation>
         <translation>Tu</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Invitat de %1</translation>

--- a/resources/langs/ru/komai_ru.ts
+++ b/resources/langs/ru/komai_ru.ts
@@ -7124,7 +7124,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>Ты</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Приглашение от %1</translation>

--- a/resources/langs/si/komai_si.ts
+++ b/resources/langs/si/komai_si.ts
@@ -7116,7 +7116,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>ඔබ</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>%1 විසින් ආරාධනා කරන ලදි</translation>

--- a/resources/langs/sr_Latn/komai_sr_Latn.ts
+++ b/resources/langs/sr_Latn/komai_sr_Latn.ts
@@ -7124,7 +7124,7 @@ Imaj na umu da se ne može deaktivirati naknadno.</translation>
         <translation>Ti</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Poziv od %1</translation>

--- a/resources/langs/sv/komai_sv.ts
+++ b/resources/langs/sv/komai_sv.ts
@@ -7116,7 +7116,7 @@ Observera att den inte kan inaktiveras efteråt.</translation>
         <translation>Du</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Inbjuden av %1</translation>

--- a/resources/langs/tr/komai_tr.ts
+++ b/resources/langs/tr/komai_tr.ts
@@ -7108,7 +7108,7 @@ Lütfen daha sonra devre dışı bırakılamayacağını unutmayın.</translatio
         <translation>Siz</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>%1 tarafından davet edildi</translation>

--- a/resources/langs/uk/komai_uk.ts
+++ b/resources/langs/uk/komai_uk.ts
@@ -7124,7 +7124,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>Ви</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Запрошено від %1</translation>

--- a/resources/langs/vi/komai_vi.ts
+++ b/resources/langs/vi/komai_vi.ts
@@ -7108,7 +7108,7 @@ Lưu ý rằng tính năng này không thể tắt sau khi đã bật.</translat
         <translation>Bạn</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>Được mời bởi %1</translation>

--- a/resources/langs/zh_CN/komai_zh_CN.ts
+++ b/resources/langs/zh_CN/komai_zh_CN.ts
@@ -7108,7 +7108,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>你</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>由 %1 邀请</translation>

--- a/resources/langs/zh_Hant/komai_zh_Hant.ts
+++ b/resources/langs/zh_Hant/komai_zh_Hant.ts
@@ -7108,7 +7108,7 @@ Please take note that it can't be disabled afterwards.</source>
         <translation>你</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+111"/>
         <location line="+2"/>
         <source>Invited by %1</source>
         <translation>由 %1 邀請</translation>

--- a/src/timeline/RoomlistModel.cpp
+++ b/src/timeline/RoomlistModel.cpp
@@ -5,6 +5,7 @@
 
 #include "RoomlistModel.h"
 
+#include <QDateTime>
 #include <QTimer>
 #include <algorithm>
 
@@ -33,6 +34,12 @@ struct MatrixNotificationFetchBatchResult
     QVector<komai::MatrixNotificationItem> items;
     QString error;
 };
+
+// A freshly-typed draft doesn't count toward the attention indicators (window
+// title, tray icon, app badge) until it has sat unsent for this long -- a
+// draft is the user's own in-progress text, not something demanding
+// attention like an incoming message.
+constexpr qint64 kDraftAttentionDelayMs = 60'000;
 
 bool
 matrixRoomSummaryEquals(const komai::MatrixRoomSummary &left, const komai::MatrixRoomSummary &right)
@@ -114,9 +121,9 @@ RoomlistModel::attentionStateForRow(const QAbstractItemModel *model, const QMode
     if (!model || !idx.isValid())
         return state;
 
-    state.hasUnread    = model->data(idx, RoomlistModel::HasUnreadMessages).toBool();
-    state.hasDraft     = model->data(idx, RoomlistModel::HasDraft).toBool();
-    state.hasHighlight = model->data(idx, RoomlistModel::HasLoudNotification).toBool();
+    state.hasUnread     = model->data(idx, RoomlistModel::HasUnreadMessages).toBool();
+    state.hasStaleDraft = model->data(idx, RoomlistModel::HasStaleDraft).toBool();
+    state.hasHighlight  = model->data(idx, RoomlistModel::HasLoudNotification).toBool();
 
     if (state.hasUnread && !state.hasHighlight) {
         const auto tags     = model->data(idx, RoomlistModel::Tags).toStringList();
@@ -342,6 +349,7 @@ RoomlistModel::roleNames() const
       {UnreadCount, "unreadCount"},
       {HasDraft, "hasDraft"},
       {DraftPreview, "draftPreview"},
+      {HasStaleDraft, "hasStaleDraft"},
       {IsInvite, "isInvite"},
       {IsSpace, "isSpace"},
       {Tags, "tags"},
@@ -394,6 +402,7 @@ RoomlistModel::resetRoomCollections(bool clearAllDrafts)
     if (clearAllDrafts) {
         if (const auto settings = UserSettings::instance())
             settings->clearAllComposerDrafts();
+        draftStartedAtMs_.clear();
     }
 }
 
@@ -452,6 +461,7 @@ RoomlistModel::removeRoomState(const QString &room_id, bool clearDraftForRoom)
     if (clearDraftForRoom) {
         if (const auto settings = UserSettings::instance())
             settings->clearComposerDraftForRoom(room_id);
+        draftStartedAtMs_.remove(room_id);
     }
 
     if (pendingCurrentRoomId_ == room_id)
@@ -820,6 +830,19 @@ RoomlistModel::hasDraft(const QString &room_id) const
     return settings && settings->hasComposerDraftForRoom(room_id);
 }
 
+bool
+RoomlistModel::hasStaleDraft(const QString &room_id) const
+{
+    if (!hasDraft(room_id))
+        return false;
+
+    const auto it = draftStartedAtMs_.constFind(room_id);
+    if (it == draftStartedAtMs_.constEnd())
+        return false;
+
+    return QDateTime::currentMSecsSinceEpoch() - it.value() >= kDraftAttentionDelayMs;
+}
+
 QString
 RoomlistModel::draftPreviewText(const QString &room_id) const
 {
@@ -846,10 +869,24 @@ RoomlistModel::persistDraftForRoom(const QString &room_id, const QString &draftT
     if (!settings)
         return;
 
-    if (draftText.trimmed().isEmpty())
+    if (draftText.trimmed().isEmpty()) {
         settings->clearComposerDraftForRoom(room_id);
-    else
+        draftStartedAtMs_.remove(room_id);
+    } else {
         settings->setComposerDraftForRoom(room_id, draftText);
+        if (!draftStartedAtMs_.contains(room_id)) {
+            draftStartedAtMs_.insert(room_id, QDateTime::currentMSecsSinceEpoch());
+            QTimer::singleShot(kDraftAttentionDelayMs, this, [this, room_id]() {
+                if (!hasStaleDraft(room_id))
+                    return;
+
+                const auto staleIdx = roomidToIndex(room_id);
+                if (staleIdx != -1)
+                    emit dataChanged(index(staleIdx), index(staleIdx), {Roles::HasStaleDraft});
+                emitAttentionCount();
+            });
+        }
+    }
 
     const auto idx = roomidToIndex(room_id);
     if (idx == -1)

--- a/src/timeline/RoomlistModel.h
+++ b/src/timeline/RoomlistModel.h
@@ -111,6 +111,7 @@ public:
         UnreadCount,
         HasDraft,
         DraftPreview,
+        HasStaleDraft,
         IsInvite,
         IsSpace,
         IsPreview,
@@ -212,17 +213,17 @@ private:
     struct AttentionState
     {
         bool hasUnread     = false;
-        bool hasDraft      = false;
+        bool hasStaleDraft = false;
         bool hasHighlight  = false;
         bool isLowPriority = false;
 
-        bool hasAnyAttention() const { return hasUnread || hasDraft || hasHighlight; }
+        bool hasAnyAttention() const { return hasUnread || hasStaleDraft || hasHighlight; }
         bool countAsActive(bool includeLowPriorityUnread) const
         {
             if (includeLowPriorityUnread)
-                return hasUnread || hasDraft;
+                return hasUnread || hasStaleDraft;
 
-            return isLowPriority ? (hasDraft || hasHighlight) : (hasUnread || hasDraft);
+            return isLowPriority ? (hasStaleDraft || hasHighlight) : (hasUnread || hasStaleDraft);
         }
     };
 
@@ -257,6 +258,7 @@ private:
     void deferCurrentRoomSelection(const QString &roomid);
     QString draftPreviewText(const QString &room_id) const;
     bool hasDraft(const QString &room_id) const;
+    bool hasStaleDraft(const QString &room_id) const;
     void persistDraftForRoom(const QString &room_id, const QString &draftText);
     void fetchPreviews(QString roomid, const std::string &from = "");
     void startMatrixBackendRoomsRefresh(uint64_t handleId);
@@ -281,6 +283,12 @@ private:
     QHash<QString, komai::MatrixRoomSummary> matrixJoinedRooms_;
     std::map<QString, bool> roomReadStatus;
     QHash<QString, std::optional<RoomInfo>> previewedRooms;
+    // Timestamp (epoch ms) of when a room's draft first became non-empty.
+    // Used to delay counting an unsent draft toward the attention indicators
+    // (window title, tray icon, app badge) until it has sat unsent for a
+    // while -- typing a message shouldn't immediately look like a new
+    // incoming message demanding attention.
+    QHash<QString, qint64> draftStartedAtMs_;
 
     std::optional<RoomPreview> currentRoomPreview_;
     quint64 currentRoomVisualStateGeneration_ = 0;

--- a/src/timeline/data/RoomlistModelData.cpp
+++ b/src/timeline/data/RoomlistModelData.cpp
@@ -146,6 +146,8 @@ RoomlistModel::commonRoomData(const QString &room_id, int role) const
         return QVariant{hasDraft(room_id)};
     case Roles::DraftPreview:
         return QVariant{draftPreviewText(room_id)};
+    case Roles::HasStaleDraft:
+        return QVariant{hasStaleDraft(room_id)};
     default:
         return std::nullopt;
     }


### PR DESCRIPTION
## Summary
- Typing a draft into the composer immediately fed into the same "attention" total that drives the window title counter, tray icon, and app badge — so an unsent draft looked exactly like an incoming unread message.
- An unsent draft now only counts toward those indicators once it has sat unsent for 60 seconds, so a few keystrokes no longer trigger a false alarm, but a message you started and genuinely forgot to send still gets flagged.
- The row-level "Draft: ..." preview and highlighting in the room list are unaffected — those still show immediately, since they're a helpful in-app hint rather than an OS-level "new message" flag.
- Translation `.ts` files updated for line-reference drift only (no string/content changes), per `docs/maintainers/translations.md`.

## Test plan
- [x] `just build`
- [x] `just test` (C++ ctest suite + Rust unit tests, all passing)
- [x] `just lint` (clang-format, translations-drift, etc. — all relevant hooks passing on the changed files)
- [x] Manual verification: launched the app, typed a draft and confirmed no immediate title bar/tray flag; confirmed the flag appears once the draft has been unsent for ~60s; screenshot-verified the tray/taskbar badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)