### PR TITLE
Keep Forward and Invite dialogs from cutting off their action button

### DIFF
--- a/resources/langs/ar/komai_ar.ts
+++ b/resources/langs/ar/komai_ar.ts
@@ -2312,12 +2312,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>إعادة توجيه الرسالة</translation>
     </message>
@@ -2369,7 +2369,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>الغرف المحددة</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>الغرف</translation>
     </message>
@@ -2404,7 +2404,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>اسم الغرفة أو عنوانها أو معرّفها...</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>إعادة توجيه</translation>
     </message>
@@ -2873,7 +2873,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>دعوة مستخدمين إلى %1</translation>
     </message>
@@ -2893,7 +2893,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>المستخدمون المحددون</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>المستخدمون</translation>
     </message>
@@ -2939,7 +2939,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>اختر مستخدمًا أو أكثر للدعوة.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>دعوة</translation>
     </message>
@@ -3756,7 +3756,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>إعادة توجيه</translation>
     </message>

--- a/resources/langs/bg/komai_bg.ts
+++ b/resources/langs/bg/komai_bg.ts
@@ -2296,7 +2296,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+164"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+183"/>
         <source>Forward message</source>
         <translation>Препрати съобщение</translation>
     </message>
@@ -2344,7 +2344,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Избрани стаи</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Стаи</translation>
     </message>
@@ -2374,17 +2374,17 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Избери една или повече стаи, към които да препратиш съобщението.</translation>
     </message>
     <message>
-        <location line="-383"/>
+        <location line="-424"/>
         <source>Close</source>
         <translation>Затвори</translation>
     </message>
     <message>
-        <location line="+77"/>
+        <location line="+118"/>
         <source>Room name, address or id...</source>
         <translation>Име на стая, адрес или id…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Препрати</translation>
     </message>
@@ -2853,7 +2853,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Покани потребители в %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Избрани потребители</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Потребители</translation>
     </message>
@@ -2919,7 +2919,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Изберете един или повече потребители за покана.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Покани</translation>
     </message>
@@ -3732,7 +3732,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Препрати</translation>
     </message>

--- a/resources/langs/ca/komai_ca.ts
+++ b/resources/langs/ca/komai_ca.ts
@@ -2296,12 +2296,12 @@ Pots indicar opcionalment un motiu perquè els altres acceptin la teva trucada:<
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Tanca</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Reenvia el missatge</translation>
     </message>
@@ -2349,7 +2349,7 @@ Pots indicar opcionalment un motiu perquè els altres acceptin la teva trucada:<
         <translation>Sales seleccionades</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Sales</translation>
     </message>
@@ -2384,7 +2384,7 @@ Pots indicar opcionalment un motiu perquè els altres acceptin la teva trucada:<
         <translation>Nom, adreça o ID de la sala…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Reenvia</translation>
     </message>
@@ -2853,7 +2853,7 @@ Pots indicar opcionalment un motiu perquè els altres acceptin la teva trucada:<
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Convida usuaris a %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Pots indicar opcionalment un motiu perquè els altres acceptin la teva trucada:<
         <translation>Usuaris seleccionats</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Usuaris</translation>
     </message>
@@ -2919,7 +2919,7 @@ Pots indicar opcionalment un motiu perquè els altres acceptin la teva trucada:<
         <translation>Trieu un o més usuaris per convidar.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Convida</translation>
     </message>
@@ -3732,7 +3732,7 @@ Pots indicar opcionalment un motiu perquè els altres acceptin la teva trucada:<
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Reenvia</translation>
     </message>

--- a/resources/langs/cs/komai_cs.ts
+++ b/resources/langs/cs/komai_cs.ts
@@ -2300,12 +2300,12 @@ Volitelně můžeš uvést důvod, proč by ostatní měli tvoje zaklepání př
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Přeposlat zprávu</translation>
     </message>
@@ -2354,7 +2354,7 @@ Volitelně můžeš uvést důvod, proč by ostatní měli tvoje zaklepání př
         <translation>Vybrané místnosti</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Místnosti</translation>
     </message>
@@ -2389,7 +2389,7 @@ Volitelně můžeš uvést důvod, proč by ostatní měli tvoje zaklepání př
         <translation>Název místnosti, adresa nebo id…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Přeposlat</translation>
     </message>
@@ -2858,7 +2858,7 @@ Volitelně můžeš uvést důvod, proč by ostatní měli tvoje zaklepání př
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Pozvat uživatele do %1</translation>
     </message>
@@ -2878,7 +2878,7 @@ Volitelně můžeš uvést důvod, proč by ostatní měli tvoje zaklepání př
         <translation>Vybraní uživatelé</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Uživatelé</translation>
     </message>
@@ -2924,7 +2924,7 @@ Volitelně můžeš uvést důvod, proč by ostatní měli tvoje zaklepání př
         <translation>Vyberte jednoho nebo více uživatelů k pozvání.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Pozvat</translation>
     </message>
@@ -3738,7 +3738,7 @@ Volitelně můžeš uvést důvod, proč by ostatní měli tvoje zaklepání př
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Přeposlat</translation>
     </message>

--- a/resources/langs/de/komai_de.ts
+++ b/resources/langs/de/komai_de.ts
@@ -2296,12 +2296,12 @@ Du kannst zusätzlich einen Grund angeben, warum die anderen dein Anklopfen anne
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Nachricht weiterleiten</translation>
     </message>
@@ -2349,7 +2349,7 @@ Du kannst zusätzlich einen Grund angeben, warum die anderen dein Anklopfen anne
         <translation>Ausgewählte Räume</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Räume</translation>
     </message>
@@ -2384,7 +2384,7 @@ Du kannst zusätzlich einen Grund angeben, warum die anderen dein Anklopfen anne
         <translation>Raumname, Adresse oder ID …</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Weiterleiten</translation>
     </message>
@@ -2853,7 +2853,7 @@ Du kannst zusätzlich einen Grund angeben, warum die anderen dein Anklopfen anne
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Lade Benutzer in %1 ein</translation>
     </message>
@@ -2873,7 +2873,7 @@ Du kannst zusätzlich einen Grund angeben, warum die anderen dein Anklopfen anne
         <translation>Ausgewählte Nutzer</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Nutzer</translation>
     </message>
@@ -2919,7 +2919,7 @@ Du kannst zusätzlich einen Grund angeben, warum die anderen dein Anklopfen anne
         <translation>Wähle einen oder mehrere Nutzer zum Einladen aus.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Einladen</translation>
     </message>
@@ -3732,7 +3732,7 @@ Du kannst zusätzlich einen Grund angeben, warum die anderen dein Anklopfen anne
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Weiterleiten</translation>
     </message>

--- a/resources/langs/el/komai_el.ts
+++ b/resources/langs/el/komai_el.ts
@@ -2296,12 +2296,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Προώθηση μηνύματος</translation>
     </message>
@@ -2349,7 +2349,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Επιλεγμένα δωμάτια</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Δωμάτια</translation>
     </message>
@@ -2384,7 +2384,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Όνομα, διεύθυνση ή αναγνωριστικό δωματίου…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Προώθηση</translation>
     </message>
@@ -2853,7 +2853,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Πρόσκληση χρηστών στο %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Επιλεγμένοι χρήστες</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Χρήστες</translation>
     </message>
@@ -2919,7 +2919,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Επιλέξτε έναν ή περισσότερους χρήστες για πρόσκληση.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Πρόσκληση</translation>
     </message>
@@ -3732,7 +3732,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Προώθηση</translation>
     </message>

--- a/resources/langs/en/komai_en.ts
+++ b/resources/langs/en/komai_en.ts
@@ -2290,12 +2290,12 @@ You may optionally provide a reason for others to accept your knock:</translatio
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation type="unfinished">Close</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation type="unfinished"/>
     </message>
@@ -2343,7 +2343,7 @@ You may optionally provide a reason for others to accept your knock:</translatio
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation type="unfinished"/>
     </message>
@@ -2378,7 +2378,7 @@ You may optionally provide a reason for others to accept your knock:</translatio
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation type="unfinished"/>
     </message>
@@ -2847,7 +2847,7 @@ You may optionally provide a reason for others to accept your knock:</translatio
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Invite users to %1</translation>
     </message>
@@ -2867,7 +2867,7 @@ You may optionally provide a reason for others to accept your knock:</translatio
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation type="unfinished">Users</translation>
     </message>
@@ -2913,7 +2913,7 @@ You may optionally provide a reason for others to accept your knock:</translatio
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Invite</translation>
     </message>
@@ -3726,7 +3726,7 @@ You may optionally provide a reason for others to accept your knock:</translatio
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation type="unfinished"/>
     </message>

--- a/resources/langs/eo/komai_eo.ts
+++ b/resources/langs/eo/komai_eo.ts
@@ -2296,12 +2296,12 @@ Vi povas aldoni noton, pri kial oni akceptu vian frapadon:</translation>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Fermi</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Plusendi mesaĝon</translation>
     </message>
@@ -2349,7 +2349,7 @@ Vi povas aldoni noton, pri kial oni akceptu vian frapadon:</translation>
         <translation>Elektitaj ĉambroj</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Ĉambroj</translation>
     </message>
@@ -2384,7 +2384,7 @@ Vi povas aldoni noton, pri kial oni akceptu vian frapadon:</translation>
         <translation>Nomo, adreso aŭ id de ĉambro…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Plusendi</translation>
     </message>
@@ -2853,7 +2853,7 @@ Vi povas aldoni noton, pri kial oni akceptu vian frapadon:</translation>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Invitu uzantojn al %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Vi povas aldoni noton, pri kial oni akceptu vian frapadon:</translation>
         <translation>Elektitaj uzantoj</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Uzantoj</translation>
     </message>
@@ -2919,7 +2919,7 @@ Vi povas aldoni noton, pri kial oni akceptu vian frapadon:</translation>
         <translation>Elektu unu aŭ pli da uzantoj por inviti.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Inviti</translation>
     </message>
@@ -3732,7 +3732,7 @@ Vi povas aldoni noton, pri kial oni akceptu vian frapadon:</translation>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Plusendi</translation>
     </message>

--- a/resources/langs/es/komai_es.ts
+++ b/resources/langs/es/komai_es.ts
@@ -2297,12 +2297,12 @@ Si el problema persiste, puedes cerrar sesión e iniciarla de nuevo, pero esto e
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Reenviar mensaje</translation>
     </message>
@@ -2350,7 +2350,7 @@ Si el problema persiste, puedes cerrar sesión e iniciarla de nuevo, pero esto e
         <translation>Salas seleccionadas</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Salas</translation>
     </message>
@@ -2385,7 +2385,7 @@ Si el problema persiste, puedes cerrar sesión e iniciarla de nuevo, pero esto e
         <translation>Nombre, dirección o ID de sala...</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Reenviar</translation>
     </message>
@@ -2856,7 +2856,7 @@ Si el problema persiste, puedes cerrar sesión e iniciarla de nuevo, pero esto e
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Invitar a los usuarios a %1</translation>
     </message>
@@ -2876,7 +2876,7 @@ Si el problema persiste, puedes cerrar sesión e iniciarla de nuevo, pero esto e
         <translation>Usuarios seleccionados</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Usuarios</translation>
     </message>
@@ -2922,7 +2922,7 @@ Si el problema persiste, puedes cerrar sesión e iniciarla de nuevo, pero esto e
         <translation>Elige uno o más usuarios para invitar.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Invitar</translation>
     </message>
@@ -3735,7 +3735,7 @@ Si el problema persiste, puedes cerrar sesión e iniciarla de nuevo, pero esto e
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Reenviar</translation>
     </message>

--- a/resources/langs/et/komai_et.ts
+++ b/resources/langs/et/komai_et.ts
@@ -2296,12 +2296,12 @@ Kui soovid, siis võid lisada ka selgituse, miks peaks sinu koputusele reageerim
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Sulge</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Edasta sõnum</translation>
     </message>
@@ -2349,7 +2349,7 @@ Kui soovid, siis võid lisada ka selgituse, miks peaks sinu koputusele reageerim
         <translation>Valitud jututoad</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Jututoad</translation>
     </message>
@@ -2384,7 +2384,7 @@ Kui soovid, siis võid lisada ka selgituse, miks peaks sinu koputusele reageerim
         <translation>Jututoa nimi, aadress või id…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Edasta</translation>
     </message>
@@ -2853,7 +2853,7 @@ Kui soovid, siis võid lisada ka selgituse, miks peaks sinu koputusele reageerim
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Kutsu kasutajaid %1 jututuppa</translation>
     </message>
@@ -2873,7 +2873,7 @@ Kui soovid, siis võid lisada ka selgituse, miks peaks sinu koputusele reageerim
         <translation>Valitud kasutajad</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Kasutajad</translation>
     </message>
@@ -2919,7 +2919,7 @@ Kui soovid, siis võid lisada ka selgituse, miks peaks sinu koputusele reageerim
         <translation>Vali üks või mitu kutsutavat kasutajat.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Saada kutse</translation>
     </message>
@@ -3732,7 +3732,7 @@ Kui soovid, siis võid lisada ka selgituse, miks peaks sinu koputusele reageerim
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Edasta</translation>
     </message>

--- a/resources/langs/fa/komai_fa.ts
+++ b/resources/langs/fa/komai_fa.ts
@@ -2292,12 +2292,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>بستن</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>ارسال پیام</translation>
     </message>
@@ -2344,7 +2344,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>اتاق‌های انتخاب‌شده</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>اتاق‌ها</translation>
     </message>
@@ -2379,7 +2379,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>نام، آدرس یا شناسه اتاق...</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>بازارسال</translation>
     </message>
@@ -2848,7 +2848,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>دعوت کاربران به %1</translation>
     </message>
@@ -2868,7 +2868,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>کاربران انتخاب‌شده</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>کاربران</translation>
     </message>
@@ -2914,7 +2914,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>یک یا چند کاربر برای دعوت انتخاب کنید.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>دعوت</translation>
     </message>
@@ -3726,7 +3726,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>بازارسال</translation>
     </message>

--- a/resources/langs/fi/komai_fi.ts
+++ b/resources/langs/fi/komai_fi.ts
@@ -2296,12 +2296,12 @@ Voit antaa valinnaisen syyn muiden hyväksyäkseen koputuksesi:</translation>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Sulje</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Välitä viesti</translation>
     </message>
@@ -2349,7 +2349,7 @@ Voit antaa valinnaisen syyn muiden hyväksyäkseen koputuksesi:</translation>
         <translation>Valitut huoneet</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Huoneet</translation>
     </message>
@@ -2384,7 +2384,7 @@ Voit antaa valinnaisen syyn muiden hyväksyäkseen koputuksesi:</translation>
         <translation>Huoneen nimi, osoite tai tunnus…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Välitä</translation>
     </message>
@@ -2853,7 +2853,7 @@ Voit antaa valinnaisen syyn muiden hyväksyäkseen koputuksesi:</translation>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Kutsu käyttäjiä %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Voit antaa valinnaisen syyn muiden hyväksyäkseen koputuksesi:</translation>
         <translation>Valitut käyttäjät</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Käyttäjät</translation>
     </message>
@@ -2919,7 +2919,7 @@ Voit antaa valinnaisen syyn muiden hyväksyäkseen koputuksesi:</translation>
         <translation>Valitse yksi tai useampi käyttäjä kutsuttavaksi.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Kutsu</translation>
     </message>
@@ -3732,7 +3732,7 @@ Voit antaa valinnaisen syyn muiden hyväksyäkseen koputuksesi:</translation>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Välitä</translation>
     </message>

--- a/resources/langs/fr/komai_fr.ts
+++ b/resources/langs/fr/komai_fr.ts
@@ -2296,12 +2296,12 @@ Eventuellement, vous pouvez fournir une explication de votre demande aux autres 
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Transférer le message</translation>
     </message>
@@ -2349,7 +2349,7 @@ Eventuellement, vous pouvez fournir une explication de votre demande aux autres 
         <translation>Salons sélectionnés</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Salons</translation>
     </message>
@@ -2384,7 +2384,7 @@ Eventuellement, vous pouvez fournir une explication de votre demande aux autres 
         <translation>Nom du salon, adresse ou identifiant…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Transférer</translation>
     </message>
@@ -2853,7 +2853,7 @@ Eventuellement, vous pouvez fournir une explication de votre demande aux autres 
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Inviter des utilisateurs dans %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Eventuellement, vous pouvez fournir une explication de votre demande aux autres 
         <translation>Utilisateurs sélectionnés</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Utilisateurs</translation>
     </message>
@@ -2919,7 +2919,7 @@ Eventuellement, vous pouvez fournir une explication de votre demande aux autres 
         <translation>Choisissez un ou plusieurs utilisateurs à inviter.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Inviter</translation>
     </message>
@@ -3732,7 +3732,7 @@ Eventuellement, vous pouvez fournir une explication de votre demande aux autres 
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Transférer</translation>
     </message>

--- a/resources/langs/hu/komai_hu.ts
+++ b/resources/langs/hu/komai_hu.ts
@@ -2292,12 +2292,12 @@ Ha a probléma továbbra is fennáll, kijelentkezhet és újra bejelentkezhet, d
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Bezárás</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Üzenet továbbítása</translation>
     </message>
@@ -2344,7 +2344,7 @@ Ha a probléma továbbra is fennáll, kijelentkezhet és újra bejelentkezhet, d
         <translation>Kiválasztott szobák</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Szobák</translation>
     </message>
@@ -2379,7 +2379,7 @@ Ha a probléma továbbra is fennáll, kijelentkezhet és újra bejelentkezhet, d
         <translation>Szoba neve, címe vagy azonosítója...</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Továbbítás</translation>
     </message>
@@ -2848,7 +2848,7 @@ Ha a probléma továbbra is fennáll, kijelentkezhet és újra bejelentkezhet, d
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Felhasználók meghívása: %1</translation>
     </message>
@@ -2868,7 +2868,7 @@ Ha a probléma továbbra is fennáll, kijelentkezhet és újra bejelentkezhet, d
         <translation>Kiválasztott felhasználók</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Felhasználók</translation>
     </message>
@@ -2914,7 +2914,7 @@ Ha a probléma továbbra is fennáll, kijelentkezhet és újra bejelentkezhet, d
         <translation>Válasszon egy vagy több felhasználót a meghíváshoz.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Meghívás</translation>
     </message>
@@ -3726,7 +3726,7 @@ Ha a probléma továbbra is fennáll, kijelentkezhet és újra bejelentkezhet, d
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Továbbítás</translation>
     </message>

--- a/resources/langs/id/komai_id.ts
+++ b/resources/langs/id/komai_id.ts
@@ -2292,12 +2292,12 @@ Anda dapat memberikan alasan untuk orang lain untuk menerima ketukanmu:</transla
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Teruskan pesan</translation>
     </message>
@@ -2344,7 +2344,7 @@ Anda dapat memberikan alasan untuk orang lain untuk menerima ketukanmu:</transla
         <translation>Ruangan yang dipilih</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Ruangan</translation>
     </message>
@@ -2379,7 +2379,7 @@ Anda dapat memberikan alasan untuk orang lain untuk menerima ketukanmu:</transla
         <translation>Nama ruangan, alamat, atau id…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Teruskan</translation>
     </message>
@@ -2848,7 +2848,7 @@ Anda dapat memberikan alasan untuk orang lain untuk menerima ketukanmu:</transla
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Undang pengguna ke %1</translation>
     </message>
@@ -2868,7 +2868,7 @@ Anda dapat memberikan alasan untuk orang lain untuk menerima ketukanmu:</transla
         <translation>Pengguna dipilih</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Pengguna</translation>
     </message>
@@ -2914,7 +2914,7 @@ Anda dapat memberikan alasan untuk orang lain untuk menerima ketukanmu:</transla
         <translation>Pilih satu atau lebih pengguna untuk diundang.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Undang</translation>
     </message>
@@ -3726,7 +3726,7 @@ Anda dapat memberikan alasan untuk orang lain untuk menerima ketukanmu:</transla
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Teruskan</translation>
     </message>

--- a/resources/langs/ie/komai_ie.ts
+++ b/resources/langs/ie/komai_ie.ts
@@ -2296,12 +2296,12 @@ Vu pote facultativmen dar un motiv por que alters accepta vun petition:</transla
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Clauder</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Transmir mesage</translation>
     </message>
@@ -2349,7 +2349,7 @@ Vu pote facultativmen dar un motiv por que alters accepta vun petition:</transla
         <translation>Chambres selectionate</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Chambres</translation>
     </message>
@@ -2384,7 +2384,7 @@ Vu pote facultativmen dar un motiv por que alters accepta vun petition:</transla
         <translation>Nomine, adresse o id del chambre…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Transmandar</translation>
     </message>
@@ -2853,7 +2853,7 @@ Vu pote facultativmen dar un motiv por que alters accepta vun petition:</transla
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Invitar usatores a %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Vu pote facultativmen dar un motiv por que alters accepta vun petition:</transla
         <translation>Usatores selectat</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Usatores</translation>
     </message>
@@ -2919,7 +2919,7 @@ Vu pote facultativmen dar un motiv por que alters accepta vun petition:</transla
         <translation>Selectionar un o pluri usatores por invitar.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Invitar</translation>
     </message>
@@ -3732,7 +3732,7 @@ Vu pote facultativmen dar un motiv por que alters accepta vun petition:</transla
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Transmandar</translation>
     </message>

--- a/resources/langs/it/komai_it.ts
+++ b/resources/langs/it/komai_it.ts
@@ -2296,12 +2296,12 @@ Se il problema persiste, puoi disconnetterti e accedere nuovamente, ma questo el
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Inoltra messaggio</translation>
     </message>
@@ -2349,7 +2349,7 @@ Se il problema persiste, puoi disconnetterti e accedere nuovamente, ma questo el
         <translation>Stanze selezionate</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Stanze</translation>
     </message>
@@ -2384,7 +2384,7 @@ Se il problema persiste, puoi disconnetterti e accedere nuovamente, ma questo el
         <translation>Nome stanza, indirizzo o ID…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Inoltra</translation>
     </message>
@@ -2853,7 +2853,7 @@ Se il problema persiste, puoi disconnetterti e accedere nuovamente, ma questo el
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Invita utenti in %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Se il problema persiste, puoi disconnetterti e accedere nuovamente, ma questo el
         <translation>Utenti selezionati</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Utenti</translation>
     </message>
@@ -2919,7 +2919,7 @@ Se il problema persiste, puoi disconnetterti e accedere nuovamente, ma questo el
         <translation>Scegli uno o più utenti da invitare.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Invita</translation>
     </message>
@@ -3732,7 +3732,7 @@ Se il problema persiste, puoi disconnetterti e accedere nuovamente, ma questo el
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Inoltra</translation>
     </message>

--- a/resources/langs/ja/komai_ja.ts
+++ b/resources/langs/ja/komai_ja.ts
@@ -2292,12 +2292,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>メッセージを転送</translation>
     </message>
@@ -2344,7 +2344,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>選択済みのルーム</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>ルーム</translation>
     </message>
@@ -2379,7 +2379,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>ルームの名前、アドレス、またはID…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>転送</translation>
     </message>
@@ -2848,7 +2848,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>%1 にユーザーを招待</translation>
     </message>
@@ -2868,7 +2868,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>選択されたユーザー</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>ユーザー</translation>
     </message>
@@ -2914,7 +2914,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>招待するユーザーを1人以上選択してください。</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>招待</translation>
     </message>
@@ -3726,7 +3726,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>転送</translation>
     </message>

--- a/resources/langs/ko/komai_ko.ts
+++ b/resources/langs/ko/komai_ko.ts
@@ -2292,12 +2292,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>메시지 전달</translation>
     </message>
@@ -2344,7 +2344,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>선택된 방</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>방</translation>
     </message>
@@ -2379,7 +2379,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>방 이름, 주소 또는 ID…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>전달</translation>
     </message>
@@ -2848,7 +2848,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>%1에 사용자 초대</translation>
     </message>
@@ -2868,7 +2868,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>선택된 사용자</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>사용자</translation>
     </message>
@@ -2914,7 +2914,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>초대할 사용자를 한 명 이상 선택하세요.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>초대</translation>
     </message>
@@ -3726,7 +3726,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>전달</translation>
     </message>

--- a/resources/langs/ml/komai_ml.ts
+++ b/resources/langs/ml/komai_ml.ts
@@ -2296,12 +2296,12 @@ If the problem persists, you can log out and sign in again, but this will delete
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>അടയ്ക്കുക</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>സന്ദേശം ഫോർവേഡ് ചെയ്യുക</translation>
     </message>
@@ -2349,7 +2349,7 @@ If the problem persists, you can log out and sign in again, but this will delete
         <translation>തിരഞ്ഞെടുത്ത മുറികൾ</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>മുറികൾ</translation>
     </message>
@@ -2384,7 +2384,7 @@ If the problem persists, you can log out and sign in again, but this will delete
         <translation>മുറിയുടെ പേര്, വിലാസം അല്ലെങ്കിൽ ഐഡി…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>കൈമാറുക</translation>
     </message>
@@ -2853,7 +2853,7 @@ If the problem persists, you can log out and sign in again, but this will delete
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>%1 - ലേക്ക് ഉപയോക്താക്കളെ ക്ഷണിക്കുക</translation>
     </message>
@@ -2873,7 +2873,7 @@ If the problem persists, you can log out and sign in again, but this will delete
         <translation>തിരഞ്ഞെടുത്ത ഉപയോക്താക്കൾ</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>ഉപയോക്താക്കൾ</translation>
     </message>
@@ -2919,7 +2919,7 @@ If the problem persists, you can log out and sign in again, but this will delete
         <translation>ക്ഷണിക്കാൻ ഒന്നോ അതിലധികമോ ഉപയോക്താക്കളെ തിരഞ്ഞെടുക്കുക.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>ക്ഷണിക്കുക</translation>
     </message>
@@ -3732,7 +3732,7 @@ If the problem persists, you can log out and sign in again, but this will delete
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>കൈമാറുക</translation>
     </message>

--- a/resources/langs/nl/komai_nl.ts
+++ b/resources/langs/nl/komai_nl.ts
@@ -2296,12 +2296,12 @@ Je kan optioneel hier een reden invoeren dat je aanklopt:</translation>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Bericht doorsturen</translation>
     </message>
@@ -2349,7 +2349,7 @@ Je kan optioneel hier een reden invoeren dat je aanklopt:</translation>
         <translation>Geselecteerde kamers</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Kamers</translation>
     </message>
@@ -2384,7 +2384,7 @@ Je kan optioneel hier een reden invoeren dat je aanklopt:</translation>
         <translation>Kamernaam, adres of id…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Doorsturen</translation>
     </message>
@@ -2853,7 +2853,7 @@ Je kan optioneel hier een reden invoeren dat je aanklopt:</translation>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Nodig gebruikers uit naar %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Je kan optioneel hier een reden invoeren dat je aanklopt:</translation>
         <translation>Geselecteerde gebruikers</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Gebruikers</translation>
     </message>
@@ -2919,7 +2919,7 @@ Je kan optioneel hier een reden invoeren dat je aanklopt:</translation>
         <translation>Kies een of meer gebruikers om uit te nodigen.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Uitnodigen</translation>
     </message>
@@ -3732,7 +3732,7 @@ Je kan optioneel hier een reden invoeren dat je aanklopt:</translation>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Doorsturen</translation>
     </message>

--- a/resources/langs/pl/komai_pl.ts
+++ b/resources/langs/pl/komai_pl.ts
@@ -2300,12 +2300,12 @@ Jeśli problem będzie się powtarzał, możesz się wylogować i zalogować pon
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Przekaż wiadomość</translation>
     </message>
@@ -2354,7 +2354,7 @@ Jeśli problem będzie się powtarzał, możesz się wylogować i zalogować pon
         <translation>Wybrane pokoje</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Pokoje</translation>
     </message>
@@ -2389,7 +2389,7 @@ Jeśli problem będzie się powtarzał, możesz się wylogować i zalogować pon
         <translation>Nazwa pokoju, adres lub ID…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Przekaż dalej</translation>
     </message>
@@ -2858,7 +2858,7 @@ Jeśli problem będzie się powtarzał, możesz się wylogować i zalogować pon
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Zaproś użytkowników do %1</translation>
     </message>
@@ -2878,7 +2878,7 @@ Jeśli problem będzie się powtarzał, możesz się wylogować i zalogować pon
         <translation>Wybrani użytkownicy</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Użytkownicy</translation>
     </message>
@@ -2924,7 +2924,7 @@ Jeśli problem będzie się powtarzał, możesz się wylogować i zalogować pon
         <translation>Wybierz jednego lub więcej użytkowników do zaproszenia.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Zaproś</translation>
     </message>
@@ -3738,7 +3738,7 @@ Jeśli problem będzie się powtarzał, możesz się wylogować i zalogować pon
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Przekaż dalej</translation>
     </message>

--- a/resources/langs/pt_BR/komai_pt_BR.ts
+++ b/resources/langs/pt_BR/komai_pt_BR.ts
@@ -2296,12 +2296,12 @@ Se o problema persistir, você pode sair e entrar novamente, mas isso apagará o
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Encaminhar mensagem</translation>
     </message>
@@ -2349,7 +2349,7 @@ Se o problema persistir, você pode sair e entrar novamente, mas isso apagará o
         <translation>Salas selecionadas</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Salas</translation>
     </message>
@@ -2384,7 +2384,7 @@ Se o problema persistir, você pode sair e entrar novamente, mas isso apagará o
         <translation>Nome, endereço ou id da sala…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Encaminhar</translation>
     </message>
@@ -2853,7 +2853,7 @@ Se o problema persistir, você pode sair e entrar novamente, mas isso apagará o
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Convidar usuários para %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Se o problema persistir, você pode sair e entrar novamente, mas isso apagará o
         <translation>Usuários selecionados</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Usuários</translation>
     </message>
@@ -2919,7 +2919,7 @@ Se o problema persistir, você pode sair e entrar novamente, mas isso apagará o
         <translation>Escolha um ou mais usuários para convidar.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Convidar</translation>
     </message>
@@ -3732,7 +3732,7 @@ Se o problema persistir, você pode sair e entrar novamente, mas isso apagará o
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Encaminhar</translation>
     </message>

--- a/resources/langs/pt_PT/komai_pt_PT.ts
+++ b/resources/langs/pt_PT/komai_pt_PT.ts
@@ -2296,12 +2296,12 @@ Se o problema persistir, pode terminar sessão e iniciar sessão novamente, mas 
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Reencaminhar mensagem</translation>
     </message>
@@ -2349,7 +2349,7 @@ Se o problema persistir, pode terminar sessão e iniciar sessão novamente, mas 
         <translation>Salas selecionadas</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Salas</translation>
     </message>
@@ -2384,7 +2384,7 @@ Se o problema persistir, pode terminar sessão e iniciar sessão novamente, mas 
         <translation>Nome, endereço ou id da sala...</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Reencaminhar</translation>
     </message>
@@ -2853,7 +2853,7 @@ Se o problema persistir, pode terminar sessão e iniciar sessão novamente, mas 
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Convidar utilizadores para %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Se o problema persistir, pode terminar sessão e iniciar sessão novamente, mas 
         <translation>Utilizadores selecionados</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Utilizadores</translation>
     </message>
@@ -2919,7 +2919,7 @@ Se o problema persistir, pode terminar sessão e iniciar sessão novamente, mas 
         <translation>Escolha um ou mais utilizadores para convidar.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Convidar</translation>
     </message>
@@ -3732,7 +3732,7 @@ Se o problema persistir, pode terminar sessão e iniciar sessão novamente, mas 
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Reencaminhar</translation>
     </message>

--- a/resources/langs/ro/komai_ro.ts
+++ b/resources/langs/ro/komai_ro.ts
@@ -2300,12 +2300,12 @@ Poți opțional oferi un motiv pentru ca alții să îți accepte cererea:</tran
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Închide</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Redirecționare mesaj</translation>
     </message>
@@ -2354,7 +2354,7 @@ Poți opțional oferi un motiv pentru ca alții să îți accepte cererea:</tran
         <translation>Camere selectate</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Camere</translation>
     </message>
@@ -2389,7 +2389,7 @@ Poți opțional oferi un motiv pentru ca alții să îți accepte cererea:</tran
         <translation>Numele camerei, adresa sau id-ul…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Redirecționare</translation>
     </message>
@@ -2858,7 +2858,7 @@ Poți opțional oferi un motiv pentru ca alții să îți accepte cererea:</tran
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Invită utilizatori în %1</translation>
     </message>
@@ -2878,7 +2878,7 @@ Poți opțional oferi un motiv pentru ca alții să îți accepte cererea:</tran
         <translation>Utilizatori selectați</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Utilizatori</translation>
     </message>
@@ -2924,7 +2924,7 @@ Poți opțional oferi un motiv pentru ca alții să îți accepte cererea:</tran
         <translation>Alege unul sau mai mulți utilizatori de invitat.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Invită</translation>
     </message>
@@ -3738,7 +3738,7 @@ Poți opțional oferi un motiv pentru ca alții să îți accepte cererea:</tran
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Redirecționare</translation>
     </message>

--- a/resources/langs/ru/komai_ru.ts
+++ b/resources/langs/ru/komai_ru.ts
@@ -2300,12 +2300,12 @@ If the problem persists, you can log out and sign in again, but this will delete
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Переслать сообщение</translation>
     </message>
@@ -2354,7 +2354,7 @@ If the problem persists, you can log out and sign in again, but this will delete
         <translation>Выбранные комнаты</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Комнаты</translation>
     </message>
@@ -2389,7 +2389,7 @@ If the problem persists, you can log out and sign in again, but this will delete
         <translation>Название, адрес или ID комнаты…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Переслать</translation>
     </message>
@@ -2858,7 +2858,7 @@ If the problem persists, you can log out and sign in again, but this will delete
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Пригласить пользователей в %1</translation>
     </message>
@@ -2878,7 +2878,7 @@ If the problem persists, you can log out and sign in again, but this will delete
         <translation>Выбранные пользователи</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Пользователи</translation>
     </message>
@@ -2924,7 +2924,7 @@ If the problem persists, you can log out and sign in again, but this will delete
         <translation>Выбери одного или нескольких пользователей для приглашения.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Пригласить</translation>
     </message>
@@ -3738,7 +3738,7 @@ If the problem persists, you can log out and sign in again, but this will delete
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Переслать</translation>
     </message>

--- a/resources/langs/si/komai_si.ts
+++ b/resources/langs/si/komai_si.ts
@@ -2296,12 +2296,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>වසන්න</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>පණිවිඩය යොමු කරන්න</translation>
     </message>
@@ -2349,7 +2349,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>තෝරාගත් කාමර</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>කාමර</translation>
     </message>
@@ -2384,7 +2384,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>කාමරයේ නම, ලිපිනය හෝ id…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>ඉදිරියට යවන්න</translation>
     </message>
@@ -2853,7 +2853,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>%1 වෙත පරිශීලකයන් ආරාධනා කරන්න</translation>
     </message>
@@ -2873,7 +2873,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>තෝරාගත් පරිශීලකයන්</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>පරිශීලකයන්</translation>
     </message>
@@ -2919,7 +2919,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>ආරාධනා කිරීම සඳහා එක් හෝ කිහිප දෙනෙකු තෝරාගන්න.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>ආරාධනා කරන්න</translation>
     </message>
@@ -3732,7 +3732,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>ඉදිරියට යවන්න</translation>
     </message>

--- a/resources/langs/sr_Latn/komai_sr_Latn.ts
+++ b/resources/langs/sr_Latn/komai_sr_Latn.ts
@@ -2300,12 +2300,12 @@ Opciono možeš navesti razlog zbog kojeg bi drugi prihvatili tvoje kucanje:</tr
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Zatvori</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Prosledi poruku</translation>
     </message>
@@ -2354,7 +2354,7 @@ Opciono možeš navesti razlog zbog kojeg bi drugi prihvatili tvoje kucanje:</tr
         <translation>Izabrane sobe</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Sobe</translation>
     </message>
@@ -2389,7 +2389,7 @@ Opciono možeš navesti razlog zbog kojeg bi drugi prihvatili tvoje kucanje:</tr
         <translation>Naziv sobe, adresa ili ID…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Prosledi</translation>
     </message>
@@ -2858,7 +2858,7 @@ Opciono možeš navesti razlog zbog kojeg bi drugi prihvatili tvoje kucanje:</tr
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Pozovi korisnike u %1</translation>
     </message>
@@ -2878,7 +2878,7 @@ Opciono možeš navesti razlog zbog kojeg bi drugi prihvatili tvoje kucanje:</tr
         <translation>Izabrani korisnici</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Korisnici</translation>
     </message>
@@ -2924,7 +2924,7 @@ Opciono možeš navesti razlog zbog kojeg bi drugi prihvatili tvoje kucanje:</tr
         <translation>Izaberi jednog ili više korisnika za pozivanje.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Pozovi</translation>
     </message>
@@ -3738,7 +3738,7 @@ Opciono možeš navesti razlog zbog kojeg bi drugi prihvatili tvoje kucanje:</tr
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Prosledi</translation>
     </message>

--- a/resources/langs/sv/komai_sv.ts
+++ b/resources/langs/sv/komai_sv.ts
@@ -2296,12 +2296,12 @@ Om problemet kvarstår kan du logga ut och logga in igen, men detta raderar din 
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Vidarebefordra meddelande</translation>
     </message>
@@ -2349,7 +2349,7 @@ Om problemet kvarstår kan du logga ut och logga in igen, men detta raderar din 
         <translation>Valda rum</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Rum</translation>
     </message>
@@ -2384,7 +2384,7 @@ Om problemet kvarstår kan du logga ut och logga in igen, men detta raderar din 
         <translation>Rumsnamn, adress eller id...</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Vidarebefordra</translation>
     </message>
@@ -2853,7 +2853,7 @@ Om problemet kvarstår kan du logga ut och logga in igen, men detta raderar din 
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Bjud in användare till %1</translation>
     </message>
@@ -2873,7 +2873,7 @@ Om problemet kvarstår kan du logga ut och logga in igen, men detta raderar din 
         <translation>Valda användare</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Användare</translation>
     </message>
@@ -2919,7 +2919,7 @@ Om problemet kvarstår kan du logga ut och logga in igen, men detta raderar din 
         <translation>Välj en eller flera användare att bjuda in.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Bjud in</translation>
     </message>
@@ -3732,7 +3732,7 @@ Om problemet kvarstår kan du logga ut och logga in igen, men detta raderar din 
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Vidarebefordra</translation>
     </message>

--- a/resources/langs/tr/komai_tr.ts
+++ b/resources/langs/tr/komai_tr.ts
@@ -2292,12 +2292,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Mesajı ilet</translation>
     </message>
@@ -2344,7 +2344,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Seçilen odalar</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Odalar</translation>
     </message>
@@ -2379,7 +2379,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Oda adı, adresi veya kimliği…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>İlet</translation>
     </message>
@@ -2848,7 +2848,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>%1'e kullanıcı davet et</translation>
     </message>
@@ -2868,7 +2868,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Seçilen kullanıcılar</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Kullanıcılar</translation>
     </message>
@@ -2914,7 +2914,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Davet etmek için bir veya daha fazla kullanıcı seçin.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Davet et</translation>
     </message>
@@ -3726,7 +3726,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>İlet</translation>
     </message>

--- a/resources/langs/uk/komai_uk.ts
+++ b/resources/langs/uk/komai_uk.ts
@@ -2300,12 +2300,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Переслати повідомлення</translation>
     </message>
@@ -2354,7 +2354,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Вибрані кімнати</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Кімнати</translation>
     </message>
@@ -2389,7 +2389,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Назва кімнати, адреса або ідентифікатор…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Переслати</translation>
     </message>
@@ -2858,7 +2858,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Запросити користувачів до %1</translation>
     </message>
@@ -2878,7 +2878,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Вибрані користувачі</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Користувачі</translation>
     </message>
@@ -2924,7 +2924,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>Виберіть одного або кількох користувачів для запрошення.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Запросити</translation>
     </message>
@@ -3738,7 +3738,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Переслати</translation>
     </message>

--- a/resources/langs/vi/komai_vi.ts
+++ b/resources/langs/vi/komai_vi.ts
@@ -2292,12 +2292,12 @@ Bạn có thể tùy chọn cung cấp lý do để người khác chấp nhận
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>Đóng</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>Chuyển tiếp tin nhắn</translation>
     </message>
@@ -2344,7 +2344,7 @@ Bạn có thể tùy chọn cung cấp lý do để người khác chấp nhận
         <translation>Phòng đã chọn</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>Phòng</translation>
     </message>
@@ -2379,7 +2379,7 @@ Bạn có thể tùy chọn cung cấp lý do để người khác chấp nhận
         <translation>Tên phòng, địa chỉ hoặc id…</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>Chuyển tiếp</translation>
     </message>
@@ -2848,7 +2848,7 @@ Bạn có thể tùy chọn cung cấp lý do để người khác chấp nhận
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>Mời người dùng vào %1</translation>
     </message>
@@ -2868,7 +2868,7 @@ Bạn có thể tùy chọn cung cấp lý do để người khác chấp nhận
         <translation>Người dùng đã chọn</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>Người dùng</translation>
     </message>
@@ -2914,7 +2914,7 @@ Bạn có thể tùy chọn cung cấp lý do để người khác chấp nhận
         <translation>Chọn một hoặc nhiều người dùng để mời.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>Mời</translation>
     </message>
@@ -3726,7 +3726,7 @@ Bạn có thể tùy chọn cung cấp lý do để người khác chấp nhận
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>Chuyển tiếp</translation>
     </message>

--- a/resources/langs/zh_CN/komai_zh_CN.ts
+++ b/resources/langs/zh_CN/komai_zh_CN.ts
@@ -2292,12 +2292,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>转发消息</translation>
     </message>
@@ -2344,7 +2344,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>已选聊天室</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>聊天室</translation>
     </message>
@@ -2379,7 +2379,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>聊天室名称、地址或 ID……</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>转发</translation>
     </message>
@@ -2848,7 +2848,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>邀请用户加入 %1</translation>
     </message>
@@ -2868,7 +2868,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>已选用户</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>用户</translation>
     </message>
@@ -2914,7 +2914,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>选择一位或多位用户进行邀请。</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>邀请</translation>
     </message>
@@ -3726,7 +3726,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>转发</translation>
     </message>

--- a/resources/langs/zh_Hant/komai_zh_Hant.ts
+++ b/resources/langs/zh_Hant/komai_zh_Hant.ts
@@ -2292,12 +2292,12 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>ForwardCompleter</name>
     <message>
-        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+284"/>
+        <location filename="../../qml/dialogs/navigation/ForwardCompleter.qml" line="+314"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location line="-120"/>
+        <location line="-131"/>
         <source>Forward message</source>
         <translation>轉發訊息</translation>
     </message>
@@ -2344,7 +2344,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>已選聊天室</translation>
     </message>
     <message>
-        <location line="+216"/>
+        <location line="+268"/>
         <source>Rooms</source>
         <translation>聊天室</translation>
     </message>
@@ -2379,7 +2379,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>聊天室名稱、地址或 ID...</translation>
     </message>
     <message>
-        <location line="+326"/>
+        <location line="+330"/>
         <source>Forward</source>
         <translation>轉傳</translation>
     </message>
@@ -2848,7 +2848,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>InviteDialog</name>
     <message>
-        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+43"/>
+        <location filename="../../qml/dialogs/room/InviteDialog.qml" line="+54"/>
         <source>Invite users to %1</source>
         <translation>邀請使用者加入 %1</translation>
     </message>
@@ -2868,7 +2868,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>已選擇的使用者</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+235"/>
         <source>Users</source>
         <translation>使用者</translation>
     </message>
@@ -2914,7 +2914,7 @@ You may optionally provide a reason for others to accept your knock:</source>
         <translation>選擇一個或多個使用者進行邀請。</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+14"/>
         <source>Invite</source>
         <translation>邀請</translation>
     </message>
@@ -3726,7 +3726,7 @@ You may optionally provide a reason for others to accept your knock:</source>
 <context>
     <name>MediaOverlay</name>
     <message>
-        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+709"/>
+        <location filename="../../qml/dialogs/media/MediaOverlay.qml" line="+712"/>
         <source>Forward</source>
         <translation>轉傳</translation>
     </message>

--- a/resources/qml/dialogs/media/MediaOverlay.qml
+++ b/resources/qml/dialogs/media/MediaOverlay.qml
@@ -276,7 +276,10 @@ Window {
         const host = mediaOverlay;
         const dialog = component.createObject(host, {
                 "roomSource": resolvedRoom,
-                "dialogViewportWidth": host.width,
+                // Qt.binding() keeps this tracking the live viewport width; a
+                // plain value here would freeze at whatever it was when the
+                // dialog opened and never follow a later window resize.
+                "dialogViewportWidth": Qt.binding(() => host.width),
                 "modalOverlayColor": mediaOverlay.modalOverlayColor,
                 "timelineSource": resolvedTimeline,
                 "timelineViewSource": resolvedTimelineView,

--- a/resources/qml/dialogs/navigation/ForwardCompleter.qml
+++ b/resources/qml/dialogs/navigation/ForwardCompleter.qml
@@ -66,6 +66,25 @@ Popup {
         return Math.max(rowH * 2, Math.min(rowH * rows, cap));
     }
 
+    // Height budget consumed by the parts of the dialog that stay pinned
+    // outside the scrollable middle section (title row, hint, and the
+    // Forward/close action row), so the middle section knows how much room
+    // it actually has left before it needs to start scrolling instead of
+    // shoving the action row off the bottom of a short window.
+    readonly property real scrollChromeHeight: topPadding + bottomPadding
+        + forwardColumn.spacing * 3
+        + titleRow.implicitHeight + hintLabel.implicitHeight + actionRow.implicitHeight
+    readonly property real availableScrollHeight: Math.max(
+        cardRowHeight * 2,
+        windowHeight - Komai.paddingLarge * 2 - scrollChromeHeight)
+
+    // Reserve the scrollbar gutter for the outer scroll area too, mirroring
+    // the per-list gutter handling below.
+    readonly property real outerScrollGutter: scrollbarsReserveGutter
+        ? (forwardScrollBar.implicitWidth + Komai.paddingSmall)
+        : 0
+    readonly property real scrollContentWidth: innerWidth - outerScrollGutter
+
     function normalizedMessageEventIds(eventIdsIn) {
         const sourceIds = eventIdsIn || [];
         const normalizedIds = [];
@@ -195,9 +214,18 @@ Popup {
                 ? dialogViewportWidth
                 : (parent ? parent.width : 900)) * 0.8
     x: Math.round(parent.width / 2 - width / 2)
-    y: anchoredY >= 0
-            ? anchoredY
-            : Math.max(Komai.paddingLarge, Math.round((parent.height - height) / 2))
+    // anchoredY pins the top so the dialog doesn't jump under the pointer as
+    // its content reflows (see onOpened below). But a value pinned while the
+    // window was tall (e.g. opened maximized, then unmaximized/shrunk) must
+    // not be allowed to push the dialog past the *current* window bounds —
+    // re-clamp live against parent.height/height on every resize.
+    y: {
+        const desired = anchoredY >= 0
+                ? anchoredY
+                : Math.round((parent.height - height) / 2);
+        const maxY = Math.max(Komai.paddingLarge, parent.height - height - Komai.paddingLarge);
+        return Math.max(Komai.paddingLarge, Math.min(desired, maxY));
+    }
 
     Overlay.modal: Rectangle {
         color: forwardMessagePopup.modalOverlayColor
@@ -255,6 +283,8 @@ Popup {
 
         // Title row
         RowLayout {
+            id: titleRow
+
             width: forwardMessagePopup.innerWidth
             spacing: Komai.paddingSmall
 
@@ -307,141 +337,26 @@ Popup {
             wrapMode: Text.Wrap
         }
 
-        // Preview of the (single) message being forwarded.
-        Loader {
-            id: replyPreviewLoader
-
-            active: forwardMessagePopup.showReplyPreview && forwardMessagePopup.messageCount === 1
-            width: forwardMessagePopup.innerWidth
-            sourceComponent: replyPreviewComponent
-        }
-
-        Component {
-            id: replyPreviewComponent
-
-            Reply {
-                id: replyPreview
-
-                clickable: false
-                eventId: mid
-                room_: activeRoom
-                property bool isReplyFromCurrentUser: {
-                    const currentUser = Komai.currentUser;
-                    const currentUserId = (currentUser && currentUser.userid)
-                            ? String(currentUser.userid)
-                            : "";
-                    return currentUserId.length > 0 && replyPreview.userId === currentUserId;
-                }
-                readonly property color previewWindowColor: (Komai.colors && Komai.colors.window !== undefined)
-                    ? Komai.colors.window
-                    : forwardMessagePopup.palette.window
-                readonly property color previewBaseColor: (Komai.colors && Komai.colors.base !== undefined)
-                    ? Komai.colors.base
-                    : forwardMessagePopup.palette.base
-                bubblePalette: activeRoom ? TimelineManager.roomUserBubblePalette(activeRoom.roomId, replyPreview.userId, roomColor, Settings.timelineUserColorCodingPolicy) : TimelineManager.userBubblePalette(replyPreview.userId, roomColor)
-                userColor: isReplyFromCurrentUser
-                    ? Komai.theme.userColorSelf
-                    : activeRoom ? TimelineManager.roomUserColor(activeRoom.roomId, replyPreview.userId, previewWindowColor, Settings.timelineUserColorCodingPolicy) : TimelineManager.userColor(replyPreview.userId, previewWindowColor)
-                roomColor: isReplyFromCurrentUser
-                    ? Komai.theme.userColorSelf
-                    : activeRoom ? TimelineManager.roomUserColor(activeRoom.roomId, replyPreview.userId, previewBaseColor, Settings.timelineUserColorCodingPolicy) : TimelineManager.userColor(replyPreview.userId, previewBaseColor)
-                limitHeight: true
-                width: forwardMessagePopup.innerWidth
-                maxWidth: forwardMessagePopup.innerWidth
-            }
-        }
-
-        // Room search
-        Components.KomaiTextField {
-            id: roomTextInput
+        // Scrollable middle section: reply preview, room search and both list
+        // panels. Its height is capped to whatever's left of the window after
+        // the title, hint and action row, so on a short window this section
+        // scrolls instead of pushing the Forward button off-screen.
+        Flickable {
+            id: forwardScrollArea
 
             width: forwardMessagePopup.innerWidth
-            font.pixelSize: Math.ceil(forwardMessagePopup.textHeight * 0.6)
-            implicitHeight: Math.max(controlHeight, Math.round(font.pixelSize * 2.0))
-            placeholderText: qsTr("Room name, address or id...")
-
-            Keys.onShortcutOverride: (event) => {
-                // Claim navigation / staging keys before the platform turns them
-                // into edit operations (Ctrl+U "clear line", etc.).
-                if (event.key === Qt.Key_Up || event.key === Qt.Key_Down
-                        || ((event.key === Qt.Key_D || event.key === Qt.Key_U)
-                            && (event.modifiers & Qt.ControlModifier))
-                        || (event.matches(StandardKey.InsertParagraphSeparator)
-                            && !(event.modifiers & Qt.ControlModifier)))
-                    event.accepted = true;
-            }
-            Keys.onPressed: (event) => {
-                if (event.key === Qt.Key_Up) {
-                    suggestionList.moveSelection(-1);
-                    event.accepted = true;
-                } else if (event.key === Qt.Key_Down) {
-                    suggestionList.moveSelection(1);
-                    event.accepted = true;
-                } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
-                    suggestionList.moveSelection(-forwardMessagePopup.pageStep);
-                    event.accepted = true;
-                } else if (event.key === Qt.Key_D && (event.modifiers & Qt.ControlModifier)) {
-                    suggestionList.moveSelection(forwardMessagePopup.pageStep);
-                    event.accepted = true;
-                } else if (event.matches(StandardKey.InsertParagraphSeparator)
-                           && !(event.modifiers & Qt.ControlModifier)) {
-                    forwardMessagePopup.stageCurrentSuggestion();
-                    event.accepted = true;
-                }
-            }
-            onTextEdited: {
-                if (forwardMessagePopup.roomCompleter)
-                    forwardMessagePopup.roomCompleter.searchString = text;
-            }
-        }
-
-        // --- Results (suggestions) ---
-        Label {
-            width: forwardMessagePopup.innerWidth
-            topPadding: Komai.paddingSmall
-            text: qsTr("Rooms")
-            color: palette.text
-            font.bold: true
-            font.pointSize: Settings.uiFontSizePt * 1.05
-        }
-
-        ListView {
-            id: suggestionList
-
-            // Reserve the scrollbar gutter so rows never sit under the bar.
-            readonly property real scrollGutter: forwardMessagePopup.scrollbarsReserveGutter
-                ? (suggestionScrollBar.implicitWidth + Komai.paddingSmall)
-                : 0
-
-            function moveSelection(delta) {
-                if (count === 0) {
-                    currentIndex = -1;
-                    return;
-                }
-                let next = (currentIndex < 0 ? 0 : currentIndex) + delta;
-                next = Math.max(0, Math.min(count - 1, next));
-                currentIndex = next;
-                positionViewAtIndex(next, ListView.Contain);
-            }
-
-            width: forwardMessagePopup.innerWidth
-            height: forwardMessagePopup.reservedListHeight(7)
+            height: Math.min(forwardScrollColumn.implicitHeight, forwardMessagePopup.availableScrollHeight)
+            contentWidth: width
+            contentHeight: forwardScrollColumn.implicitHeight
             clip: true
-            model: forwardMessagePopup.roomCompleter
-            spacing: forwardMessagePopup.listSpacing
             boundsBehavior: Flickable.StopAtBounds
-            highlightFollowsCurrentItem: true
-            keyNavigationEnabled: false
 
-            onCountChanged: {
-                if (count > 0 && (currentIndex < 0 || currentIndex >= count))
-                    currentIndex = 0;
-                else if (count === 0)
-                    currentIndex = -1;
+            Components.FlickableWheelBooster {
+                flickable: forwardScrollArea
             }
 
             ScrollBar.vertical: ScrollBar {
-                id: suggestionScrollBar
+                id: forwardScrollBar
 
                 policy: {
                     switch (forwardMessagePopup.scrollbarPolicySetting) {
@@ -450,226 +365,386 @@ Popup {
                     case Settings.ScrollbarPolicy.Never:
                         return ScrollBar.AlwaysOff;
                     default:
-                        return suggestionList.contentHeight > suggestionList.height
+                        return forwardScrollArea.contentHeight > forwardScrollArea.height
                             ? ScrollBar.AlwaysOn
                             : ScrollBar.AlwaysOff;
                     }
                 }
             }
 
-            delegate: AbstractButton {
-                id: suggestionDelegate
+            Column {
+                id: forwardScrollColumn
 
-                readonly property string rawRoomId: model.rawroomid
-                readonly property bool alreadySelected: forwardMessagePopup.recipientCount >= 0
-                    && forwardMessagePopup.containsRecipient(model.rawroomid)
-                readonly property bool current: model.index === suggestionList.currentIndex
+                width: forwardMessagePopup.scrollContentWidth
+                spacing: Komai.paddingSmall
 
-                width: suggestionList.width - suggestionList.scrollGutter
-                implicitHeight: suggestionRow.implicitHeight + Komai.paddingSmall * 2
-                leftPadding: Komai.paddingMedium
-                rightPadding: Komai.paddingMedium
-                enabled: !alreadySelected
-                hoverEnabled: true
-                activeFocusOnTab: false
-                onClicked: {
-                    suggestionList.currentIndex = model.index;
-                    forwardMessagePopup.addRecipient(model.rawroomid);
-                }
-                onHoveredChanged: {
-                    if (hovered && enabled)
-                        suggestionList.currentIndex = model.index;
+                // Preview of the (single) message being forwarded.
+                Loader {
+                    id: replyPreviewLoader
+
+                    active: forwardMessagePopup.showReplyPreview && forwardMessagePopup.messageCount === 1
+                    width: forwardMessagePopup.scrollContentWidth
+                    sourceComponent: replyPreviewComponent
                 }
 
-                background: Rectangle {
-                    radius: Komai.paddingMedium
-                    color: {
-                        if (suggestionDelegate.current && suggestionDelegate.enabled)
-                            return palette.highlight;
-                        if (suggestionDelegate.alreadySelected)
-                            return Qt.tint(palette.window,
-                                           Qt.rgba(palette.highlight.r, palette.highlight.g, palette.highlight.b, 0.22));
-                        return palette.window;
-                    }
-                    border.width: 1
-                    border.color: suggestionDelegate.alreadySelected
-                        ? palette.highlight
-                        : Komai.theme.separator
-                }
+                Component {
+                    id: replyPreviewComponent
 
-                contentItem: RowLayout {
-                    id: suggestionRow
+                    Reply {
+                        id: replyPreview
 
-                    spacing: Komai.paddingMedium
-
-                    Components.Avatar {
-                        Layout.preferredWidth: Komai.iconSize
-                        Layout.preferredHeight: Komai.iconSize
-                        Layout.alignment: Qt.AlignVCenter
-                        displayName: model.roomName
-                        roomid: model.rawroomid
-                        url: (model.avatarUrl || "").replace("mxc://", "image://MxcImage/")
-                        enabled: false
-                    }
-
-                    Label {
-                        Layout.fillWidth: true
-                        Layout.alignment: Qt.AlignVCenter
-                        text: model.roomName
-                        textFormat: Text.PlainText
-                        color: suggestionDelegate.current && suggestionDelegate.enabled
-                            ? palette.highlightedText
-                            : suggestionDelegate.alreadySelected
-                                ? palette.buttonText
-                                : palette.text
-                        font.italic: model.isTombstoned
-                        font.pointSize: Settings.uiFontSizePt
-                        elide: Text.ElideRight
-                    }
-
-                    Label {
-                        visible: model.isSpace
-                        Layout.alignment: Qt.AlignVCenter
-                        text: qsTr("(Space)")
-                        color: suggestionDelegate.current && suggestionDelegate.enabled
-                            ? palette.highlightedText
-                            : palette.buttonText
-                        font.pointSize: Settings.uiFontSizePt * 0.9
-                    }
-
-                    Image {
-                        Layout.alignment: Qt.AlignVCenter
-                        Layout.preferredWidth: visible ? 18 : 0
-                        Layout.preferredHeight: 18
-                        visible: suggestionDelegate.alreadySelected
-                        fillMode: Image.PreserveAspectFit
-                        source: visible
-                            ? "image://colorimage/:/icons/icons/ui/double-checkmark.svg?" + palette.highlight
-                            : ""
+                        clickable: false
+                        eventId: mid
+                        room_: activeRoom
+                        property bool isReplyFromCurrentUser: {
+                            const currentUser = Komai.currentUser;
+                            const currentUserId = (currentUser && currentUser.userid)
+                                    ? String(currentUser.userid)
+                                    : "";
+                            return currentUserId.length > 0 && replyPreview.userId === currentUserId;
+                        }
+                        readonly property color previewWindowColor: (Komai.colors && Komai.colors.window !== undefined)
+                            ? Komai.colors.window
+                            : forwardMessagePopup.palette.window
+                        readonly property color previewBaseColor: (Komai.colors && Komai.colors.base !== undefined)
+                            ? Komai.colors.base
+                            : forwardMessagePopup.palette.base
+                        bubblePalette: activeRoom ? TimelineManager.roomUserBubblePalette(activeRoom.roomId, replyPreview.userId, roomColor, Settings.timelineUserColorCodingPolicy) : TimelineManager.userBubblePalette(replyPreview.userId, roomColor)
+                        userColor: isReplyFromCurrentUser
+                            ? Komai.theme.userColorSelf
+                            : activeRoom ? TimelineManager.roomUserColor(activeRoom.roomId, replyPreview.userId, previewWindowColor, Settings.timelineUserColorCodingPolicy) : TimelineManager.userColor(replyPreview.userId, previewWindowColor)
+                        roomColor: isReplyFromCurrentUser
+                            ? Komai.theme.userColorSelf
+                            : activeRoom ? TimelineManager.roomUserColor(activeRoom.roomId, replyPreview.userId, previewBaseColor, Settings.timelineUserColorCodingPolicy) : TimelineManager.userColor(replyPreview.userId, previewBaseColor)
+                        limitHeight: true
+                        width: forwardMessagePopup.scrollContentWidth
+                        maxWidth: forwardMessagePopup.scrollContentWidth
                     }
                 }
-            }
 
-            Label {
-                anchors.centerIn: parent
-                width: parent.width - Komai.paddingLarge * 2
-                visible: suggestionList.count === 0
-                horizontalAlignment: Text.AlignHCenter
-                wrapMode: Text.WordWrap
-                color: palette.buttonText
-                font.pointSize: Settings.uiFontSizePt * 0.95
-                text: (roomTextInput.text.trim().length > 0)
-                    ? qsTr("No matching rooms found.")
-                    : qsTr("Start typing to find a room.")
-            }
-        }
+                // Room search
+                Components.KomaiTextField {
+                    id: roomTextInput
 
-        // --- Staging (selected recipients) ---
-        Label {
-            width: forwardMessagePopup.innerWidth
-            topPadding: Komai.paddingSmall
-            text: forwardMessagePopup.selectedHeadingText()
-            color: palette.text
-            font.bold: true
-            font.pointSize: Settings.uiFontSizePt * 1.05
-        }
+                    width: forwardMessagePopup.scrollContentWidth
+                    font.pixelSize: Math.ceil(forwardMessagePopup.textHeight * 0.6)
+                    implicitHeight: Math.max(controlHeight, Math.round(font.pixelSize * 2.0))
+                    placeholderText: qsTr("Room name, address or id...")
 
-        ListView {
-            id: recipientsList
-
-            readonly property real scrollGutter: forwardMessagePopup.scrollbarsReserveGutter
-                ? (recipientsScrollBar.implicitWidth + Komai.paddingSmall)
-                : 0
-
-            width: forwardMessagePopup.innerWidth
-            height: forwardMessagePopup.reservedListHeight(5)
-            clip: true
-            model: recipientsModel
-            spacing: forwardMessagePopup.listSpacing
-            boundsBehavior: Flickable.StopAtBounds
-
-            ScrollBar.vertical: ScrollBar {
-                id: recipientsScrollBar
-
-                policy: {
-                    switch (forwardMessagePopup.scrollbarPolicySetting) {
-                    case Settings.ScrollbarPolicy.Always:
-                        return ScrollBar.AlwaysOn;
-                    case Settings.ScrollbarPolicy.Never:
-                        return ScrollBar.AlwaysOff;
-                    default:
-                        return recipientsList.contentHeight > recipientsList.height
-                            ? ScrollBar.AlwaysOn
-                            : ScrollBar.AlwaysOff;
+                    Keys.onShortcutOverride: (event) => {
+                        // Claim navigation / staging keys before the platform turns them
+                        // into edit operations (Ctrl+U "clear line", etc.).
+                        if (event.key === Qt.Key_Up || event.key === Qt.Key_Down
+                                || ((event.key === Qt.Key_D || event.key === Qt.Key_U)
+                                    && (event.modifiers & Qt.ControlModifier))
+                                || (event.matches(StandardKey.InsertParagraphSeparator)
+                                    && !(event.modifiers & Qt.ControlModifier)))
+                            event.accepted = true;
+                    }
+                    Keys.onPressed: (event) => {
+                        if (event.key === Qt.Key_Up) {
+                            suggestionList.moveSelection(-1);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_Down) {
+                            suggestionList.moveSelection(1);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
+                            suggestionList.moveSelection(-forwardMessagePopup.pageStep);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_D && (event.modifiers & Qt.ControlModifier)) {
+                            suggestionList.moveSelection(forwardMessagePopup.pageStep);
+                            event.accepted = true;
+                        } else if (event.matches(StandardKey.InsertParagraphSeparator)
+                                   && !(event.modifiers & Qt.ControlModifier)) {
+                            forwardMessagePopup.stageCurrentSuggestion();
+                            event.accepted = true;
+                        }
+                    }
+                    onTextEdited: {
+                        if (forwardMessagePopup.roomCompleter)
+                            forwardMessagePopup.roomCompleter.searchString = text;
                     }
                 }
-            }
 
-            delegate: Rectangle {
-                width: recipientsList.width - recipientsList.scrollGutter
-                implicitHeight: recipientRow.implicitHeight + Komai.paddingSmall * 2
-                color: palette.window
-                radius: Komai.paddingMedium
-                border.color: Komai.theme.separator
-                border.width: 1
+                // --- Results (suggestions) ---
+                Label {
+                    width: forwardMessagePopup.scrollContentWidth
+                    topPadding: Komai.paddingSmall
+                    text: qsTr("Rooms")
+                    color: palette.text
+                    font.bold: true
+                    font.pointSize: Settings.uiFontSizePt * 1.05
+                }
 
-                RowLayout {
-                    id: recipientRow
+                ListView {
+                    id: suggestionList
 
-                    anchors.fill: parent
-                    anchors.leftMargin: Komai.paddingMedium
-                    anchors.rightMargin: Komai.paddingSmall
-                    anchors.topMargin: Komai.paddingSmall
-                    anchors.bottomMargin: Komai.paddingSmall
-                    spacing: Komai.paddingMedium
+                    // Reserve the scrollbar gutter so rows never sit under the bar.
+                    readonly property real scrollGutter: forwardMessagePopup.scrollbarsReserveGutter
+                        ? (suggestionScrollBar.implicitWidth + Komai.paddingSmall)
+                        : 0
 
-                    Components.Avatar {
-                        Layout.preferredWidth: Komai.iconSize
-                        Layout.preferredHeight: Komai.iconSize
-                        Layout.alignment: Qt.AlignVCenter
-                        displayName: model.roomName
-                        roomid: model.roomId
-                        url: (model.avatarUrl || "").replace("mxc://", "image://MxcImage/")
-                        enabled: false
+                    function moveSelection(delta) {
+                        if (count === 0) {
+                            currentIndex = -1;
+                            return;
+                        }
+                        let next = (currentIndex < 0 ? 0 : currentIndex) + delta;
+                        next = Math.max(0, Math.min(count - 1, next));
+                        currentIndex = next;
+                        positionViewAtIndex(next, ListView.Contain);
                     }
 
-                    Label {
-                        Layout.fillWidth: true
-                        Layout.alignment: Qt.AlignVCenter
-                        text: model.roomName
-                        color: palette.text
-                        font.pointSize: Settings.uiFontSizePt
-                        elide: Text.ElideRight
+                    width: forwardMessagePopup.scrollContentWidth
+                    height: forwardMessagePopup.reservedListHeight(7)
+                    clip: true
+                    model: forwardMessagePopup.roomCompleter
+                    spacing: forwardMessagePopup.listSpacing
+                    boundsBehavior: Flickable.StopAtBounds
+                    highlightFollowsCurrentItem: true
+                    keyNavigationEnabled: false
+
+                    onCountChanged: {
+                        if (count > 0 && (currentIndex < 0 || currentIndex >= count))
+                            currentIndex = 0;
+                        else if (count === 0)
+                            currentIndex = -1;
                     }
 
-                    Components.ImageButton {
-                        Layout.alignment: Qt.AlignVCenter
-                        Layout.preferredWidth: Komai.iconSize
-                        Layout.preferredHeight: Komai.iconSize
-                        activeFocusOnTab: false
+                    ScrollBar.vertical: ScrollBar {
+                        id: suggestionScrollBar
+
+                        policy: {
+                            switch (forwardMessagePopup.scrollbarPolicySetting) {
+                            case Settings.ScrollbarPolicy.Always:
+                                return ScrollBar.AlwaysOn;
+                            case Settings.ScrollbarPolicy.Never:
+                                return ScrollBar.AlwaysOff;
+                            default:
+                                return suggestionList.contentHeight > suggestionList.height
+                                    ? ScrollBar.AlwaysOn
+                                    : ScrollBar.AlwaysOff;
+                            }
+                        }
+                    }
+
+                    delegate: AbstractButton {
+                        id: suggestionDelegate
+
+                        readonly property string rawRoomId: model.rawroomid
+                        readonly property bool alreadySelected: forwardMessagePopup.recipientCount >= 0
+                            && forwardMessagePopup.containsRecipient(model.rawroomid)
+                        readonly property bool current: model.index === suggestionList.currentIndex
+
+                        width: suggestionList.width - suggestionList.scrollGutter
+                        implicitHeight: suggestionRow.implicitHeight + Komai.paddingSmall * 2
+                        leftPadding: Komai.paddingMedium
+                        rightPadding: Komai.paddingMedium
+                        enabled: !alreadySelected
                         hoverEnabled: true
-                        toolTipText: qsTr("Remove")
-                        toolTipVisible: hovered
-                        image: ":/icons/icons/ui/dismiss.svg"
-                        onClicked: forwardMessagePopup.removeRecipient(model.roomId)
+                        activeFocusOnTab: false
+                        onClicked: {
+                            suggestionList.currentIndex = model.index;
+                            forwardMessagePopup.addRecipient(model.rawroomid);
+                        }
+                        onHoveredChanged: {
+                            if (hovered && enabled)
+                                suggestionList.currentIndex = model.index;
+                        }
+
+                        background: Rectangle {
+                            radius: Komai.paddingMedium
+                            color: {
+                                if (suggestionDelegate.current && suggestionDelegate.enabled)
+                                    return palette.highlight;
+                                if (suggestionDelegate.alreadySelected)
+                                    return Qt.tint(palette.window,
+                                                   Qt.rgba(palette.highlight.r, palette.highlight.g, palette.highlight.b, 0.22));
+                                return palette.window;
+                            }
+                            border.width: 1
+                            border.color: suggestionDelegate.alreadySelected
+                                ? palette.highlight
+                                : Komai.theme.separator
+                        }
+
+                        contentItem: RowLayout {
+                            id: suggestionRow
+
+                            spacing: Komai.paddingMedium
+
+                            Components.Avatar {
+                                Layout.preferredWidth: Komai.iconSize
+                                Layout.preferredHeight: Komai.iconSize
+                                Layout.alignment: Qt.AlignVCenter
+                                displayName: model.roomName
+                                roomid: model.rawroomid
+                                url: (model.avatarUrl || "").replace("mxc://", "image://MxcImage/")
+                                enabled: false
+                            }
+
+                            Label {
+                                Layout.fillWidth: true
+                                Layout.alignment: Qt.AlignVCenter
+                                text: model.roomName
+                                textFormat: Text.PlainText
+                                color: suggestionDelegate.current && suggestionDelegate.enabled
+                                    ? palette.highlightedText
+                                    : suggestionDelegate.alreadySelected
+                                        ? palette.buttonText
+                                        : palette.text
+                                font.italic: model.isTombstoned
+                                font.pointSize: Settings.uiFontSizePt
+                                elide: Text.ElideRight
+                            }
+
+                            Label {
+                                visible: model.isSpace
+                                Layout.alignment: Qt.AlignVCenter
+                                text: qsTr("(Space)")
+                                color: suggestionDelegate.current && suggestionDelegate.enabled
+                                    ? palette.highlightedText
+                                    : palette.buttonText
+                                font.pointSize: Settings.uiFontSizePt * 0.9
+                            }
+
+                            Image {
+                                Layout.alignment: Qt.AlignVCenter
+                                Layout.preferredWidth: visible ? 18 : 0
+                                Layout.preferredHeight: 18
+                                visible: suggestionDelegate.alreadySelected
+                                fillMode: Image.PreserveAspectFit
+                                source: visible
+                                    ? "image://colorimage/:/icons/icons/ui/double-checkmark.svg?" + palette.highlight
+                                    : ""
+                            }
+                        }
+                    }
+
+                    Label {
+                        anchors.centerIn: parent
+                        width: parent.width - Komai.paddingLarge * 2
+                        visible: suggestionList.count === 0
+                        horizontalAlignment: Text.AlignHCenter
+                        wrapMode: Text.WordWrap
+                        color: palette.buttonText
+                        font.pointSize: Settings.uiFontSizePt * 0.95
+                        text: (roomTextInput.text.trim().length > 0)
+                            ? qsTr("No matching rooms found.")
+                            : qsTr("Start typing to find a room.")
                     }
                 }
-            }
 
-            Label {
-                anchors.centerIn: parent
-                width: parent.width - Komai.paddingLarge * 2
-                visible: recipientsList.count === 0
-                horizontalAlignment: Text.AlignHCenter
-                wrapMode: Text.WordWrap
-                color: palette.buttonText
-                font.pointSize: Settings.uiFontSizePt * 0.95
-                text: qsTr("Choose one or more rooms to forward the message to.")
-            }
-        }
+                // --- Staging (selected recipients) ---
+                Label {
+                    width: forwardMessagePopup.scrollContentWidth
+                    topPadding: Komai.paddingSmall
+                    text: forwardMessagePopup.selectedHeadingText()
+                    color: palette.text
+                    font.bold: true
+                    font.pointSize: Settings.uiFontSizePt * 1.05
+                }
+
+                ListView {
+                    id: recipientsList
+
+                    readonly property real scrollGutter: forwardMessagePopup.scrollbarsReserveGutter
+                        ? (recipientsScrollBar.implicitWidth + Komai.paddingSmall)
+                        : 0
+
+                    width: forwardMessagePopup.scrollContentWidth
+                    height: forwardMessagePopup.reservedListHeight(5)
+                    clip: true
+                    model: recipientsModel
+                    spacing: forwardMessagePopup.listSpacing
+                    boundsBehavior: Flickable.StopAtBounds
+
+                    ScrollBar.vertical: ScrollBar {
+                        id: recipientsScrollBar
+
+                        policy: {
+                            switch (forwardMessagePopup.scrollbarPolicySetting) {
+                            case Settings.ScrollbarPolicy.Always:
+                                return ScrollBar.AlwaysOn;
+                            case Settings.ScrollbarPolicy.Never:
+                                return ScrollBar.AlwaysOff;
+                            default:
+                                return recipientsList.contentHeight > recipientsList.height
+                                    ? ScrollBar.AlwaysOn
+                                    : ScrollBar.AlwaysOff;
+                            }
+                        }
+                    }
+
+                    delegate: Rectangle {
+                        width: recipientsList.width - recipientsList.scrollGutter
+                        implicitHeight: recipientRow.implicitHeight + Komai.paddingSmall * 2
+                        color: palette.window
+                        radius: Komai.paddingMedium
+                        border.color: Komai.theme.separator
+                        border.width: 1
+
+                        RowLayout {
+                            id: recipientRow
+
+                            anchors.fill: parent
+                            anchors.leftMargin: Komai.paddingMedium
+                            anchors.rightMargin: Komai.paddingSmall
+                            anchors.topMargin: Komai.paddingSmall
+                            anchors.bottomMargin: Komai.paddingSmall
+                            spacing: Komai.paddingMedium
+
+                            Components.Avatar {
+                                Layout.preferredWidth: Komai.iconSize
+                                Layout.preferredHeight: Komai.iconSize
+                                Layout.alignment: Qt.AlignVCenter
+                                displayName: model.roomName
+                                roomid: model.roomId
+                                url: (model.avatarUrl || "").replace("mxc://", "image://MxcImage/")
+                                enabled: false
+                            }
+
+                            Label {
+                                Layout.fillWidth: true
+                                Layout.alignment: Qt.AlignVCenter
+                                text: model.roomName
+                                color: palette.text
+                                font.pointSize: Settings.uiFontSizePt
+                                elide: Text.ElideRight
+                            }
+
+                            Components.ImageButton {
+                                Layout.alignment: Qt.AlignVCenter
+                                Layout.preferredWidth: Komai.iconSize
+                                Layout.preferredHeight: Komai.iconSize
+                                activeFocusOnTab: false
+                                hoverEnabled: true
+                                toolTipText: qsTr("Remove")
+                                toolTipVisible: hovered
+                                image: ":/icons/icons/ui/dismiss.svg"
+                                onClicked: forwardMessagePopup.removeRecipient(model.roomId)
+                            }
+                        }
+                    }
+
+                    Label {
+                        anchors.centerIn: parent
+                        width: parent.width - Komai.paddingLarge * 2
+                        visible: recipientsList.count === 0
+                        horizontalAlignment: Text.AlignHCenter
+                        wrapMode: Text.WordWrap
+                        color: palette.buttonText
+                        font.pointSize: Settings.uiFontSizePt * 0.95
+                        text: qsTr("Choose one or more rooms to forward the message to.")
+                    }
+                }
+            } // forwardScrollColumn
+        } // forwardScrollArea
 
         // Action row
         RowLayout {
+            id: actionRow
+
             width: forwardMessagePopup.innerWidth
             spacing: Komai.paddingMedium
 

--- a/resources/qml/dialogs/room/InviteDialog.qml
+++ b/resources/qml/dialogs/room/InviteDialog.qml
@@ -39,6 +39,17 @@ OverlayDialog {
         return Math.max(rowH * 2, Math.min(rowH * rows, cap));
     }
 
+    // Height budget for the scrollable middle section (search + both list
+    // panels): whatever's left below the dialog's fixed y position and above
+    // the pinned Invite button, so a short window scrolls that section
+    // instead of pushing the Invite button off-screen. Mirrors the same fix
+    // in ForwardCompleter.qml.
+    readonly property real inviteScrollChromeHeight: overlayDialogChromeHeight
+        + Komai.paddingMedium + inviteButton.implicitHeight
+    readonly property real availableScrollHeight: Math.max(
+        cardRowHeight * 2,
+        windowHeight - y - Komai.paddingLarge - inviteScrollChromeHeight)
+
     title: invitees && invitees.roomName.length > 0
         ? qsTr("Invite users to %1").arg(invitees.roomName)
         : qsTr("Invite users")
@@ -139,511 +150,555 @@ OverlayDialog {
         onActivated: inviteDialogRoot.cleanUpAndClose()
     }
 
-    // --- Search ---
-    KomaiTextField {
-        id: inviteeEntry
-
-        readonly property string localHomeserver: {
-            const uid = Settings.userId;
-            const colonIdx = uid.indexOf(":");
-            return colonIdx >= 0 ? uid.substring(colonIdx + 1) : "";
-        }
-
-        function normalizedMxid(input) {
-            var t = input.trim();
-            if (t.length === 0)
-                return "";
-            if (t.charAt(0) !== "@")
-                t = "@" + t;
-            if (t.indexOf(":") < 0 && localHomeserver.length > 0)
-                t = t + ":" + localHomeserver;
-            return t;
-        }
-
-        property string resolvedMxid: normalizedMxid(text)
-        property bool isValidMxid: resolvedMxid.match("@.+?:.{3,}")
+    // Scrollable middle section: search, direct-invite card and both list
+    // panels. Capped to availableScrollHeight so on a short window this
+    // section scrolls instead of the Invite button running off the bottom.
+    Flickable {
+        id: inviteScrollArea
 
         Layout.fillWidth: true
-        placeholderText: qsTr("Search by name or @user:example.com")
-        font.pixelSize: Math.ceil(Komai.fontPixelSize * 1.2)
+        Layout.preferredHeight: Math.min(inviteScrollColumn.implicitHeight, inviteDialogRoot.availableScrollHeight)
+        contentWidth: width
+        contentHeight: inviteScrollColumn.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
 
-        Keys.onShortcutOverride: (event) => {
-            // Claim navigation / staging keys before the platform turns them
-            // into edit operations (Ctrl+U "clear line", etc.).
-            if (event.key === Qt.Key_Up || event.key === Qt.Key_Down
-                    || ((event.key === Qt.Key_D || event.key === Qt.Key_U)
-                        && (event.modifiers & Qt.ControlModifier))
-                    || (event.matches(StandardKey.InsertParagraphSeparator)
-                        && !(event.modifiers & Qt.ControlModifier)))
-                event.accepted = true;
-        }
-        Keys.onPressed: (event) => {
-            if (event.key === Qt.Key_Up) {
-                searchResults.moveSelection(-1);
-                event.accepted = true;
-            } else if (event.key === Qt.Key_Down) {
-                searchResults.moveSelection(1);
-                event.accepted = true;
-            } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
-                searchResults.moveSelection(-searchResults.pageStep);
-                event.accepted = true;
-            } else if (event.key === Qt.Key_D && (event.modifiers & Qt.ControlModifier)) {
-                searchResults.moveSelection(searchResults.pageStep);
-                event.accepted = true;
-            } else if (event.matches(StandardKey.InsertParagraphSeparator)
-                       && !(event.modifiers & Qt.ControlModifier)) {
-                inviteDialogRoot.stageCurrentResult();
-                event.accepted = true;
-            }
-        }
-        onTextChanged: {
-            if (text.trim().length === 0)
-                userDirectory.setSearchString("");
-            else
-                searchTimer.restart();
+        FlickableWheelBooster {
+            flickable: inviteScrollArea
         }
 
-        Timer {
-            id: searchTimer
+        ScrollBar.vertical: ScrollBar {
+            id: inviteScrollBar
 
-            interval: 350
-            onTriggered: {
-                if (inviteeEntry.text.trim().length > 0)
-                    userDirectory.setSearchString(inviteeEntry.text.trim());
-            }
-        }
-    }
-
-    // Direct MXID invite card — shown when input is a valid MXID
-    AbstractButton {
-        id: directInviteCard
-
-        readonly property bool activeState: hovered || pressed
-        readonly property bool alreadyAdded: inviteDialogRoot.selectedCount > 0
-            && inviteDialogRoot.invitees.containsUser(inviteeEntry.resolvedMxid)
-        property string resolvedDisplayName: ""
-        property string resolvedAvatarUrl: ""
-        property string resolvedMxid: ""
-
-        function resetResolved() {
-            resolvedDisplayName = "";
-            resolvedAvatarUrl = "";
-            resolvedMxid = "";
-        }
-
-        Layout.fillWidth: true
-        activeFocusOnTab: false
-        visible: inviteeEntry.isValidMxid && !alreadyAdded
-        implicitHeight: directInviteRow.implicitHeight + Komai.paddingSmall * 2
-        onClicked: inviteDialogRoot.addInvite(inviteeEntry.resolvedMxid,
-            directInviteCard.resolvedDisplayName, directInviteCard.resolvedAvatarUrl, false)
-
-        Connections {
-            target: inviteeEntry
-            function onResolvedMxidChanged() {
-                directInviteCard.resetResolved();
-                if (inviteeEntry.isValidMxid)
-                    userDirectory.resolveUser(inviteeEntry.resolvedMxid);
-            }
-        }
-
-        Connections {
-            target: userDirectory
-            function onUserResolved(mxid, displayName, avatarUrl) {
-                if (mxid === inviteeEntry.resolvedMxid) {
-                    directInviteCard.resolvedMxid = mxid;
-                    directInviteCard.resolvedDisplayName = displayName;
-                    directInviteCard.resolvedAvatarUrl = avatarUrl;
+            policy: {
+                switch (inviteDialogRoot.scrollbarPolicySetting) {
+                case Settings.ScrollbarPolicy.Always:
+                    return ScrollBar.AlwaysOn;
+                case Settings.ScrollbarPolicy.Never:
+                    return ScrollBar.AlwaysOff;
+                default:
+                    return inviteScrollArea.contentHeight > inviteScrollArea.height
+                        ? ScrollBar.AlwaysOn
+                        : ScrollBar.AlwaysOff;
                 }
             }
         }
 
-        background: Rectangle {
-            radius: Komai.paddingMedium
-            color: directInviteCard.activeState ? palette.dark : palette.window
-            border.color: Komai.theme.separator
-            border.width: 1
-        }
+        ColumnLayout {
+            id: inviteScrollColumn
 
-        contentItem: RowLayout {
-            id: directInviteRow
-
+            width: inviteScrollArea.width
             spacing: Komai.paddingMedium
 
-            Avatar {
-                Layout.preferredWidth: Komai.iconSize
-                Layout.preferredHeight: Komai.iconSize
-                Layout.alignment: Qt.AlignVCenter
-                Layout.leftMargin: Komai.paddingMedium
-                userid: inviteeEntry.resolvedMxid
-                displayName: directInviteCard.resolvedDisplayName
-                url: (directInviteCard.resolvedAvatarUrl || "").replace("mxc://", "image://MxcImage/")
-                enabled: false
-            }
+            // --- Search ---
+            KomaiTextField {
+                id: inviteeEntry
 
-            ColumnLayout {
+                readonly property string localHomeserver: {
+                    const uid = Settings.userId;
+                    const colonIdx = uid.indexOf(":");
+                    return colonIdx >= 0 ? uid.substring(colonIdx + 1) : "";
+                }
+
+                function normalizedMxid(input) {
+                    var t = input.trim();
+                    if (t.length === 0)
+                        return "";
+                    if (t.charAt(0) !== "@")
+                        t = "@" + t;
+                    if (t.indexOf(":") < 0 && localHomeserver.length > 0)
+                        t = t + ":" + localHomeserver;
+                    return t;
+                }
+
+                property string resolvedMxid: normalizedMxid(text)
+                property bool isValidMxid: resolvedMxid.match("@.+?:.{3,}")
+
                 Layout.fillWidth: true
-                spacing: Komai.paddingSmall
+                placeholderText: qsTr("Search by name or @user:example.com")
+                font.pixelSize: Math.ceil(Komai.fontPixelSize * 1.2)
+
+                Keys.onShortcutOverride: (event) => {
+                    // Claim navigation / staging keys before the platform turns them
+                    // into edit operations (Ctrl+U "clear line", etc.).
+                    if (event.key === Qt.Key_Up || event.key === Qt.Key_Down
+                            || ((event.key === Qt.Key_D || event.key === Qt.Key_U)
+                                && (event.modifiers & Qt.ControlModifier))
+                            || (event.matches(StandardKey.InsertParagraphSeparator)
+                                && !(event.modifiers & Qt.ControlModifier)))
+                        event.accepted = true;
+                }
+                Keys.onPressed: (event) => {
+                    if (event.key === Qt.Key_Up) {
+                        searchResults.moveSelection(-1);
+                        event.accepted = true;
+                    } else if (event.key === Qt.Key_Down) {
+                        searchResults.moveSelection(1);
+                        event.accepted = true;
+                    } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
+                        searchResults.moveSelection(-searchResults.pageStep);
+                        event.accepted = true;
+                    } else if (event.key === Qt.Key_D && (event.modifiers & Qt.ControlModifier)) {
+                        searchResults.moveSelection(searchResults.pageStep);
+                        event.accepted = true;
+                    } else if (event.matches(StandardKey.InsertParagraphSeparator)
+                               && !(event.modifiers & Qt.ControlModifier)) {
+                        inviteDialogRoot.stageCurrentResult();
+                        event.accepted = true;
+                    }
+                }
+                onTextChanged: {
+                    if (text.trim().length === 0)
+                        userDirectory.setSearchString("");
+                    else
+                        searchTimer.restart();
+                }
+
+                Timer {
+                    id: searchTimer
+
+                    interval: 350
+                    onTriggered: {
+                        if (inviteeEntry.text.trim().length > 0)
+                            userDirectory.setSearchString(inviteeEntry.text.trim());
+                    }
+                }
+            }
+
+            // Direct MXID invite card — shown when input is a valid MXID
+            AbstractButton {
+                id: directInviteCard
+
+                readonly property bool activeState: hovered || pressed
+                readonly property bool alreadyAdded: inviteDialogRoot.selectedCount > 0
+                    && inviteDialogRoot.invitees.containsUser(inviteeEntry.resolvedMxid)
+                property string resolvedDisplayName: ""
+                property string resolvedAvatarUrl: ""
+                property string resolvedMxid: ""
+
+                function resetResolved() {
+                    resolvedDisplayName = "";
+                    resolvedAvatarUrl = "";
+                    resolvedMxid = "";
+                }
+
+                Layout.fillWidth: true
+                activeFocusOnTab: false
+                visible: inviteeEntry.isValidMxid && !alreadyAdded
+                implicitHeight: directInviteRow.implicitHeight + Komai.paddingSmall * 2
+                onClicked: inviteDialogRoot.addInvite(inviteeEntry.resolvedMxid,
+                    directInviteCard.resolvedDisplayName, directInviteCard.resolvedAvatarUrl, false)
+
+                Connections {
+                    target: inviteeEntry
+                    function onResolvedMxidChanged() {
+                        directInviteCard.resetResolved();
+                        if (inviteeEntry.isValidMxid)
+                            userDirectory.resolveUser(inviteeEntry.resolvedMxid);
+                    }
+                }
+
+                Connections {
+                    target: userDirectory
+                    function onUserResolved(mxid, displayName, avatarUrl) {
+                        if (mxid === inviteeEntry.resolvedMxid) {
+                            directInviteCard.resolvedMxid = mxid;
+                            directInviteCard.resolvedDisplayName = displayName;
+                            directInviteCard.resolvedAvatarUrl = avatarUrl;
+                        }
+                    }
+                }
+
+                background: Rectangle {
+                    radius: Komai.paddingMedium
+                    color: directInviteCard.activeState ? palette.dark : palette.window
+                    border.color: Komai.theme.separator
+                    border.width: 1
+                }
+
+                contentItem: RowLayout {
+                    id: directInviteRow
+
+                    spacing: Komai.paddingMedium
+
+                    Avatar {
+                        Layout.preferredWidth: Komai.iconSize
+                        Layout.preferredHeight: Komai.iconSize
+                        Layout.alignment: Qt.AlignVCenter
+                        Layout.leftMargin: Komai.paddingMedium
+                        userid: inviteeEntry.resolvedMxid
+                        displayName: directInviteCard.resolvedDisplayName
+                        url: (directInviteCard.resolvedAvatarUrl || "").replace("mxc://", "image://MxcImage/")
+                        enabled: false
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Komai.paddingSmall
+
+                        Label {
+                            Layout.fillWidth: true
+                            text: directInviteCard.resolvedDisplayName || qsTr("Invite directly")
+                            color: directInviteCard.activeState ? palette.brightText : palette.text
+                            font.pointSize: Settings.uiFontSizePt
+                            font.italic: !directInviteCard.resolvedDisplayName
+                            elide: Text.ElideRight
+                        }
+
+                        Label {
+                            Layout.fillWidth: true
+                            text: inviteeEntry.resolvedMxid
+                            color: directInviteCard.activeState ? palette.brightText : palette.buttonText
+                            font.pointSize: Settings.uiFontSizePt * 0.9
+                            elide: Text.ElideRight
+                        }
+                    }
+
+                    Image {
+                        Layout.alignment: Qt.AlignVCenter
+                        Layout.preferredWidth: 18
+                        Layout.preferredHeight: 18
+                        Layout.rightMargin: Komai.paddingMedium
+                        fillMode: Image.PreserveAspectFit
+                        source: "image://colorimage/:/icons/icons/ui/plus-circle.svg?"
+                            + (directInviteCard.activeState ? palette.brightText : palette.buttonText)
+                    }
+                }
+
+                KomaiCursorShape {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                }
+            }
+
+            // --- Results (directory matches) ---
+            Label {
+                Layout.fillWidth: true
+                Layout.topMargin: Komai.paddingSmall
+                text: qsTr("Users")
+                color: palette.text
+                font.bold: true
+                font.pointSize: Settings.uiFontSizePt * 1.1
+            }
+
+            ListView {
+                id: searchResults
+
+                // How far Ctrl+D / Ctrl+U jump through the result list.
+                readonly property int pageStep: 5
+                // Reserve the scrollbar gutter so rows never sit under the bar.
+                readonly property real scrollGutter: inviteDialogRoot.scrollbarsReserveGutter
+                    ? (searchScrollBar.implicitWidth + Komai.paddingSmall)
+                    : 0
+
+                function moveSelection(delta) {
+                    if (count === 0) {
+                        currentIndex = -1;
+                        return;
+                    }
+                    let next = (currentIndex < 0 ? 0 : currentIndex) + delta;
+                    next = Math.max(0, Math.min(count - 1, next));
+                    currentIndex = next;
+                    positionViewAtIndex(next, ListView.Contain);
+                }
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: inviteDialogRoot.reservedListHeight(6)
+                model: userDirectory
+                clip: true
+                spacing: inviteDialogRoot.listSpacing
+                boundsBehavior: Flickable.StopAtBounds
+                highlightFollowsCurrentItem: true
+                keyNavigationEnabled: false
+
+                onCountChanged: {
+                    if (count > 0 && (currentIndex < 0 || currentIndex >= count))
+                        currentIndex = 0;
+                    else if (count === 0)
+                        currentIndex = -1;
+                }
+
+                FlickableWheelBooster { flickable: searchResults }
+
+                ScrollBar.vertical: ScrollBar {
+                    id: searchScrollBar
+
+                    policy: {
+                        switch (inviteDialogRoot.scrollbarPolicySetting) {
+                        case Settings.ScrollbarPolicy.Always:
+                            return ScrollBar.AlwaysOn;
+                        case Settings.ScrollbarPolicy.Never:
+                            return ScrollBar.AlwaysOff;
+                        default:
+                            return searchResults.contentHeight > searchResults.height
+                                ? ScrollBar.AlwaysOn
+                                : ScrollBar.AlwaysOff;
+                        }
+                    }
+                }
+
+                delegate: AbstractButton {
+                    id: resultDelegate
+
+                    readonly property bool alreadySelected: inviteDialogRoot.selectedCount > 0
+                        && inviteDialogRoot.invitees.containsUser(model.userid)
+                    readonly property bool current: model.index === searchResults.currentIndex
+                    property string userIdText: model.userid
+                    property string displayNameText: model.displayName
+                    property string avatarUrlText: model.avatarUrl
+
+                    width: searchResults.width - searchResults.scrollGutter
+                    implicitHeight: resultRow.implicitHeight + Komai.paddingSmall * 2
+                    hoverEnabled: true
+                    enabled: !alreadySelected
+                    activeFocusOnTab: false
+                    onClicked: {
+                        searchResults.currentIndex = model.index;
+                        inviteDialogRoot.addInvite(userIdText, displayNameText, avatarUrlText, true);
+                    }
+                    onHoveredChanged: {
+                        if (hovered && enabled)
+                            searchResults.currentIndex = model.index;
+                    }
+
+                    background: Rectangle {
+                        radius: Komai.paddingMedium
+                        color: {
+                            if (resultDelegate.current && resultDelegate.enabled)
+                                return palette.highlight;
+                            if (resultDelegate.alreadySelected)
+                                return Qt.tint(palette.window,
+                                               Qt.rgba(palette.highlight.r, palette.highlight.g, palette.highlight.b, 0.22));
+                            return palette.window;
+                        }
+                        border.width: 1
+                        border.color: resultDelegate.alreadySelected
+                            ? palette.highlight
+                            : Komai.theme.separator
+                    }
+
+                    contentItem: RowLayout {
+                        id: resultRow
+
+                        spacing: Komai.paddingMedium
+
+                        Avatar {
+                            Layout.preferredWidth: Komai.iconSize
+                            Layout.preferredHeight: Komai.iconSize
+                            Layout.alignment: Qt.AlignVCenter
+                            Layout.leftMargin: Komai.paddingMedium
+                            userid: resultDelegate.userIdText
+                            url: (resultDelegate.avatarUrlText || "").replace("mxc://", "image://MxcImage/")
+                            displayName: resultDelegate.displayNameText
+                            enabled: false
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: Komai.paddingSmall
+
+                            Label {
+                                Layout.fillWidth: true
+                                text: resultDelegate.displayNameText || qsTr("Unknown display name")
+                                color: resultDelegate.current && resultDelegate.enabled
+                                    ? palette.highlightedText
+                                    : resultDelegate.alreadySelected
+                                        ? palette.buttonText
+                                        : resultDelegate.displayNameText ? palette.text : palette.buttonText
+                                font.pointSize: Settings.uiFontSizePt
+                                font.italic: !resultDelegate.displayNameText
+                                elide: Text.ElideRight
+                            }
+
+                            Label {
+                                Layout.fillWidth: true
+                                text: resultDelegate.userIdText
+                                color: resultDelegate.current && resultDelegate.enabled
+                                    ? palette.highlightedText
+                                    : palette.buttonText
+                                font.pointSize: Settings.uiFontSizePt * 0.9
+                                elide: Text.ElideRight
+                            }
+                        }
+
+                        Image {
+                            Layout.alignment: Qt.AlignVCenter
+                            Layout.preferredWidth: visible ? 18 : 0
+                            Layout.preferredHeight: 18
+                            Layout.rightMargin: Komai.paddingMedium
+                            visible: resultDelegate.alreadySelected
+                            fillMode: Image.PreserveAspectFit
+                            source: visible
+                                ? "image://colorimage/:/icons/icons/ui/double-checkmark.svg?" + palette.highlight
+                                : ""
+                        }
+                    }
+
+                    KomaiCursorShape {
+                        anchors.fill: parent
+                        cursorShape: resultDelegate.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    }
+                }
 
                 Label {
-                    Layout.fillWidth: true
-                    text: directInviteCard.resolvedDisplayName || qsTr("Invite directly")
-                    color: directInviteCard.activeState ? palette.brightText : palette.text
-                    font.pointSize: Settings.uiFontSizePt
-                    font.italic: !directInviteCard.resolvedDisplayName
-                    elide: Text.ElideRight
+                    anchors.centerIn: parent
+                    visible: searchResults.count === 0 && inviteeEntry.text.trim().length === 0
+                    text: qsTr("Type a search query. Results will appear here.")
+                    color: palette.buttonText
+                    font.pointSize: Settings.uiFontSizePt * 0.95
                 }
 
-                Label {
-                    Layout.fillWidth: true
-                    text: inviteeEntry.resolvedMxid
-                    color: directInviteCard.activeState ? palette.brightText : palette.buttonText
-                    font.pointSize: Settings.uiFontSizePt * 0.9
-                    elide: Text.ElideRight
-                }
-            }
-
-            Image {
-                Layout.alignment: Qt.AlignVCenter
-                Layout.preferredWidth: 18
-                Layout.preferredHeight: 18
-                Layout.rightMargin: Komai.paddingMedium
-                fillMode: Image.PreserveAspectFit
-                source: "image://colorimage/:/icons/icons/ui/plus-circle.svg?"
-                    + (directInviteCard.activeState ? palette.brightText : palette.buttonText)
-            }
-        }
-
-        KomaiCursorShape {
-            anchors.fill: parent
-            cursorShape: Qt.PointingHandCursor
-        }
-    }
-
-    // --- Results (directory matches) ---
-    Label {
-        Layout.fillWidth: true
-        Layout.topMargin: Komai.paddingSmall
-        text: qsTr("Users")
-        color: palette.text
-        font.bold: true
-        font.pointSize: Settings.uiFontSizePt * 1.1
-    }
-
-    ListView {
-        id: searchResults
-
-        // How far Ctrl+D / Ctrl+U jump through the result list.
-        readonly property int pageStep: 5
-        // Reserve the scrollbar gutter so rows never sit under the bar.
-        readonly property real scrollGutter: inviteDialogRoot.scrollbarsReserveGutter
-            ? (searchScrollBar.implicitWidth + Komai.paddingSmall)
-            : 0
-
-        function moveSelection(delta) {
-            if (count === 0) {
-                currentIndex = -1;
-                return;
-            }
-            let next = (currentIndex < 0 ? 0 : currentIndex) + delta;
-            next = Math.max(0, Math.min(count - 1, next));
-            currentIndex = next;
-            positionViewAtIndex(next, ListView.Contain);
-        }
-
-        Layout.fillWidth: true
-        Layout.preferredHeight: inviteDialogRoot.reservedListHeight(6)
-        model: userDirectory
-        clip: true
-        spacing: inviteDialogRoot.listSpacing
-        boundsBehavior: Flickable.StopAtBounds
-        highlightFollowsCurrentItem: true
-        keyNavigationEnabled: false
-
-        onCountChanged: {
-            if (count > 0 && (currentIndex < 0 || currentIndex >= count))
-                currentIndex = 0;
-            else if (count === 0)
-                currentIndex = -1;
-        }
-
-        FlickableWheelBooster { flickable: searchResults }
-
-        ScrollBar.vertical: ScrollBar {
-            id: searchScrollBar
-
-            policy: {
-                switch (inviteDialogRoot.scrollbarPolicySetting) {
-                case Settings.ScrollbarPolicy.Always:
-                    return ScrollBar.AlwaysOn;
-                case Settings.ScrollbarPolicy.Never:
-                    return ScrollBar.AlwaysOff;
-                default:
-                    return searchResults.contentHeight > searchResults.height
-                        ? ScrollBar.AlwaysOn
-                        : ScrollBar.AlwaysOff;
-                }
-            }
-        }
-
-        delegate: AbstractButton {
-            id: resultDelegate
-
-            readonly property bool alreadySelected: inviteDialogRoot.selectedCount > 0
-                && inviteDialogRoot.invitees.containsUser(model.userid)
-            readonly property bool current: model.index === searchResults.currentIndex
-            property string userIdText: model.userid
-            property string displayNameText: model.displayName
-            property string avatarUrlText: model.avatarUrl
-
-            width: searchResults.width - searchResults.scrollGutter
-            implicitHeight: resultRow.implicitHeight + Komai.paddingSmall * 2
-            hoverEnabled: true
-            enabled: !alreadySelected
-            activeFocusOnTab: false
-            onClicked: {
-                searchResults.currentIndex = model.index;
-                inviteDialogRoot.addInvite(userIdText, displayNameText, avatarUrlText, true);
-            }
-            onHoveredChanged: {
-                if (hovered && enabled)
-                    searchResults.currentIndex = model.index;
-            }
-
-            background: Rectangle {
-                radius: Komai.paddingMedium
-                color: {
-                    if (resultDelegate.current && resultDelegate.enabled)
-                        return palette.highlight;
-                    if (resultDelegate.alreadySelected)
-                        return Qt.tint(palette.window,
-                                       Qt.rgba(palette.highlight.r, palette.highlight.g, palette.highlight.b, 0.22));
-                    return palette.window;
-                }
-                border.width: 1
-                border.color: resultDelegate.alreadySelected
-                    ? palette.highlight
-                    : Komai.theme.separator
-            }
-
-            contentItem: RowLayout {
-                id: resultRow
-
-                spacing: Komai.paddingMedium
-
-                Avatar {
-                    Layout.preferredWidth: Komai.iconSize
-                    Layout.preferredHeight: Komai.iconSize
-                    Layout.alignment: Qt.AlignVCenter
-                    Layout.leftMargin: Komai.paddingMedium
-                    userid: resultDelegate.userIdText
-                    url: (resultDelegate.avatarUrlText || "").replace("mxc://", "image://MxcImage/")
-                    displayName: resultDelegate.displayNameText
-                    enabled: false
-                }
-
-                ColumnLayout {
-                    Layout.fillWidth: true
+                Column {
+                    anchors.centerIn: parent
                     spacing: Komai.paddingSmall
+                    visible: searchResults.count === 0
+                        && inviteeEntry.text.trim().length > 0
+                        && !searchTimer.running
+                        && !userDirectory.searchingUsers
 
                     Label {
-                        Layout.fillWidth: true
-                        text: resultDelegate.displayNameText || qsTr("Unknown display name")
-                        color: resultDelegate.current && resultDelegate.enabled
-                            ? palette.highlightedText
-                            : resultDelegate.alreadySelected
-                                ? palette.buttonText
-                                : resultDelegate.displayNameText ? palette.text : palette.buttonText
-                        font.pointSize: Settings.uiFontSizePt
-                        font.italic: !resultDelegate.displayNameText
-                        elide: Text.ElideRight
-                    }
-
-                    Label {
-                        Layout.fillWidth: true
-                        text: resultDelegate.userIdText
-                        color: resultDelegate.current && resultDelegate.enabled
-                            ? palette.highlightedText
-                            : palette.buttonText
-                        font.pointSize: Settings.uiFontSizePt * 0.9
-                        elide: Text.ElideRight
-                    }
-                }
-
-                Image {
-                    Layout.alignment: Qt.AlignVCenter
-                    Layout.preferredWidth: visible ? 18 : 0
-                    Layout.preferredHeight: 18
-                    Layout.rightMargin: Komai.paddingMedium
-                    visible: resultDelegate.alreadySelected
-                    fillMode: Image.PreserveAspectFit
-                    source: visible
-                        ? "image://colorimage/:/icons/icons/ui/double-checkmark.svg?" + palette.highlight
-                        : ""
-                }
-            }
-
-            KomaiCursorShape {
-                anchors.fill: parent
-                cursorShape: resultDelegate.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-            }
-        }
-
-        Label {
-            anchors.centerIn: parent
-            visible: searchResults.count === 0 && inviteeEntry.text.trim().length === 0
-            text: qsTr("Type a search query. Results will appear here.")
-            color: palette.buttonText
-            font.pointSize: Settings.uiFontSizePt * 0.95
-        }
-
-        Column {
-            anchors.centerIn: parent
-            spacing: Komai.paddingSmall
-            visible: searchResults.count === 0
-                && inviteeEntry.text.trim().length > 0
-                && !searchTimer.running
-                && !userDirectory.searchingUsers
-
-            Label {
-                anchors.horizontalCenter: parent.horizontalCenter
-                text: qsTr("No matching users found.")
-                color: palette.buttonText
-                font.pointSize: 1.1 * Settings.uiFontSizePt
-            }
-
-            Label {
-                anchors.horizontalCenter: parent.horizontalCenter
-                visible: inviteeEntry.isValidMxid
-                text: qsTr("Use the suggestion above to invite by Matrix ID.")
-                color: palette.buttonText
-                font.pointSize: Settings.uiFontSizePt
-            }
-        }
-
-        Spinner {
-            anchors.centerIn: parent
-            height: 48
-            running: searchResults.count === 0
-                && inviteeEntry.text.trim().length > 0
-                && (searchTimer.running || userDirectory.searchingUsers)
-            visible: running
-        }
-    }
-
-    // --- Staging (selected users) ---
-    Label {
-        Layout.fillWidth: true
-        Layout.topMargin: Komai.paddingSmall
-        text: inviteDialogRoot.selectedHeadingText()
-        color: palette.text
-        font.bold: true
-        font.pointSize: Settings.uiFontSizePt * 1.1
-    }
-
-    ListView {
-        id: selectedInvitees
-
-        readonly property real scrollGutter: inviteDialogRoot.scrollbarsReserveGutter
-            ? (selectedScrollBar.implicitWidth + Komai.paddingSmall)
-            : 0
-
-        Layout.fillWidth: true
-        Layout.preferredHeight: inviteDialogRoot.reservedListHeight(4)
-        clip: true
-        model: inviteDialogRoot.invitees
-        spacing: inviteDialogRoot.listSpacing
-        boundsBehavior: Flickable.StopAtBounds
-
-        ScrollBar.vertical: ScrollBar {
-            id: selectedScrollBar
-
-            policy: {
-                switch (inviteDialogRoot.scrollbarPolicySetting) {
-                case Settings.ScrollbarPolicy.Always:
-                    return ScrollBar.AlwaysOn;
-                case Settings.ScrollbarPolicy.Never:
-                    return ScrollBar.AlwaysOff;
-                default:
-                    return selectedInvitees.contentHeight > selectedInvitees.height
-                        ? ScrollBar.AlwaysOn
-                        : ScrollBar.AlwaysOff;
-                }
-            }
-        }
-
-        delegate: Rectangle {
-            width: selectedInvitees.width - selectedInvitees.scrollGutter
-            implicitHeight: selectedInviteeRow.implicitHeight + Komai.paddingSmall * 2
-            color: palette.window
-            radius: Komai.paddingMedium
-            border.color: Komai.theme.separator
-            border.width: 1
-
-            RowLayout {
-                id: selectedInviteeRow
-
-                anchors.fill: parent
-                anchors.margins: Komai.paddingSmall
-                spacing: Komai.paddingMedium
-
-                AvatarUserFlipButton {
-                    Layout.preferredWidth: Komai.iconSize
-                    Layout.preferredHeight: Komai.iconSize
-                    Layout.alignment: Qt.AlignVCenter
-                    avatarButtonSize: Komai.iconSize
-                    cleanFront: true
-                    avatarDisplayName: model.displayName
-                    avatarUrl: (model.avatarUrl || "").replace("mxc://", "image://MxcImage/")
-                    avatarUserId: model.mxid
-                    badgeIconSource: ":/icons/icons/ui/person.svg"
-                    onLeftClicked: TimelineManager.openGlobalUserProfile(model.mxid)
-                }
-
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: Komai.paddingSmall
-
-                    Label {
-                        Layout.fillWidth: true
-                        text: model.displayName || qsTr("Unknown display name")
-                        color: model.displayName ? palette.text : palette.buttonText
-                        font.pointSize: Settings.uiFontSizePt
-                        font.italic: !model.displayName
-                        elide: Text.ElideRight
-                    }
-
-                    Label {
-                        Layout.fillWidth: true
-                        text: model.mxid
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: qsTr("No matching users found.")
                         color: palette.buttonText
-                        font.pointSize: Settings.uiFontSizePt * 0.9
-                        elide: Text.ElideRight
+                        font.pointSize: 1.1 * Settings.uiFontSizePt
+                    }
+
+                    Label {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible: inviteeEntry.isValidMxid
+                        text: qsTr("Use the suggestion above to invite by Matrix ID.")
+                        color: palette.buttonText
+                        font.pointSize: Settings.uiFontSizePt
                     }
                 }
 
-                KomaiButton {
-                    Layout.alignment: Qt.AlignVCenter
-                    text: qsTr("Remove")
-                    icon.source: "qrc:/icons/icons/ui/delete.svg"
-                    onClicked: inviteDialogRoot.invitees.removeUser(model.mxid)
+                Spinner {
+                    anchors.centerIn: parent
+                    height: 48
+                    running: searchResults.count === 0
+                        && inviteeEntry.text.trim().length > 0
+                        && (searchTimer.running || userDirectory.searchingUsers)
+                    visible: running
                 }
             }
-        }
 
-        Label {
-            anchors.centerIn: parent
-            width: parent.width - Komai.paddingLarge * 2
-            visible: selectedInvitees.count === 0
-            horizontalAlignment: Text.AlignHCenter
-            wrapMode: Text.WordWrap
-            text: qsTr("Choose one or more users to invite.")
-            color: palette.buttonText
-            font.pointSize: Settings.uiFontSizePt * 0.95
-        }
-    }
+            // --- Staging (selected users) ---
+            Label {
+                Layout.fillWidth: true
+                Layout.topMargin: Komai.paddingSmall
+                text: inviteDialogRoot.selectedHeadingText()
+                color: palette.text
+                font.bold: true
+                font.pointSize: Settings.uiFontSizePt * 1.1
+            }
+
+            ListView {
+                id: selectedInvitees
+
+                readonly property real scrollGutter: inviteDialogRoot.scrollbarsReserveGutter
+                    ? (selectedScrollBar.implicitWidth + Komai.paddingSmall)
+                    : 0
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: inviteDialogRoot.reservedListHeight(4)
+                clip: true
+                model: inviteDialogRoot.invitees
+                spacing: inviteDialogRoot.listSpacing
+                boundsBehavior: Flickable.StopAtBounds
+
+                ScrollBar.vertical: ScrollBar {
+                    id: selectedScrollBar
+
+                    policy: {
+                        switch (inviteDialogRoot.scrollbarPolicySetting) {
+                        case Settings.ScrollbarPolicy.Always:
+                            return ScrollBar.AlwaysOn;
+                        case Settings.ScrollbarPolicy.Never:
+                            return ScrollBar.AlwaysOff;
+                        default:
+                            return selectedInvitees.contentHeight > selectedInvitees.height
+                                ? ScrollBar.AlwaysOn
+                                : ScrollBar.AlwaysOff;
+                        }
+                    }
+                }
+
+                delegate: Rectangle {
+                    width: selectedInvitees.width - selectedInvitees.scrollGutter
+                    implicitHeight: selectedInviteeRow.implicitHeight + Komai.paddingSmall * 2
+                    color: palette.window
+                    radius: Komai.paddingMedium
+                    border.color: Komai.theme.separator
+                    border.width: 1
+
+                    RowLayout {
+                        id: selectedInviteeRow
+
+                        anchors.fill: parent
+                        anchors.margins: Komai.paddingSmall
+                        spacing: Komai.paddingMedium
+
+                        AvatarUserFlipButton {
+                            Layout.preferredWidth: Komai.iconSize
+                            Layout.preferredHeight: Komai.iconSize
+                            Layout.alignment: Qt.AlignVCenter
+                            avatarButtonSize: Komai.iconSize
+                            cleanFront: true
+                            avatarDisplayName: model.displayName
+                            avatarUrl: (model.avatarUrl || "").replace("mxc://", "image://MxcImage/")
+                            avatarUserId: model.mxid
+                            badgeIconSource: ":/icons/icons/ui/person.svg"
+                            onLeftClicked: TimelineManager.openGlobalUserProfile(model.mxid)
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: Komai.paddingSmall
+
+                            Label {
+                                Layout.fillWidth: true
+                                text: model.displayName || qsTr("Unknown display name")
+                                color: model.displayName ? palette.text : palette.buttonText
+                                font.pointSize: Settings.uiFontSizePt
+                                font.italic: !model.displayName
+                                elide: Text.ElideRight
+                            }
+
+                            Label {
+                                Layout.fillWidth: true
+                                text: model.mxid
+                                color: palette.buttonText
+                                font.pointSize: Settings.uiFontSizePt * 0.9
+                                elide: Text.ElideRight
+                            }
+                        }
+
+                        KomaiButton {
+                            Layout.alignment: Qt.AlignVCenter
+                            text: qsTr("Remove")
+                            icon.source: "qrc:/icons/icons/ui/delete.svg"
+                            onClicked: inviteDialogRoot.invitees.removeUser(model.mxid)
+                        }
+                    }
+                }
+
+                Label {
+                    anchors.centerIn: parent
+                    width: parent.width - Komai.paddingLarge * 2
+                    visible: selectedInvitees.count === 0
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.WordWrap
+                    text: qsTr("Choose one or more users to invite.")
+                    color: palette.buttonText
+                    font.pointSize: Settings.uiFontSizePt * 0.95
+                }
+            }
+        } // inviteScrollColumn
+    } // inviteScrollArea
 
     KomaiButton {
+        id: inviteButton
+
         Layout.alignment: Qt.AlignRight
         activeFocusOnTab: true
         focusPolicy: Qt.StrongFocus

--- a/resources/qml/shell/Root.qml
+++ b/resources/qml/shell/Root.qml
@@ -78,7 +78,10 @@ function openCatalogDialog(componentUrl, properties) {
 
         var dialog = createDialog(componentCatalog.navigationForwardCompleterDialog, {
                 "roomSource": room,
-                "dialogViewportWidth": timelineRoot.width,
+                // Qt.binding() keeps this tracking the live viewport width; a
+                // plain value here would freeze at whatever it was when the
+                // dialog opened and never follow a later window resize.
+                "dialogViewportWidth": Qt.binding(() => timelineRoot.width),
                 "modalOverlayColor": timelineRoot.overlayBackdropColor,
                 "timelineSource": timeline ?? null,
                 "timelineViewSource": timelineView ?? null,


### PR DESCRIPTION
## What

Both the **Forward message** and **Invite users** dialogs stacked a
title, a search field and two list panels with no height cap and no
scrolling. On a short window (or after unmaximizing a window that was
tall when the dialog opened), that stack could exceed the visible
window height and push the Forward/Invite button off-screen entirely,
with no way to reach it.

## Fixes

- **ForwardCompleter.qml**: wrap the reply preview, room search field
  and both room lists in a `Flickable` capped to whatever space is
  actually left below the header and above the pinned Forward button,
  so a short window scrolls that middle section instead of overflowing.
- **InviteDialog.qml**: same treatment for the search field,
  direct-invite card and both user lists, capped above the pinned
  Invite button.
- **ForwardCompleter.qml**: the dialog pins its vertical position
  (`anchoredY`) once, on open, to avoid jumping under the pointer as
  content reflows. That pin was never re-validated against the window
  afterward — open while maximized/tall, then shrink the window, and
  the dialog stayed pinned near its old (now out-of-bounds) position
  even though its height correctly shrank. `y` now re-clamps live
  against the current window/dialog height on every resize.
- **Root.qml / MediaOverlay.qml**: `dialogViewportWidth` was passed to
  `Component.createObject(...)` as a plain value, which is a one-time
  snapshot, not a live binding — the dialog's width froze at whatever
  the viewport was when it opened and never tracked later resizes.
  Wrapped in `Qt.binding()` so it stays live.

## Testing

- Rebuilt (`just build`) after each change; QML AOT-compiles cleanly.
- Verified the reactive-height and position-clamp mechanics in isolated
  `qml6` repros (headless, no real account/data involved) before and
  after each fix, confirming the exact before/after numbers.
- Manually verified in the running app: Forward popup on a short
  window, on a maximized-then-shrunk window, and on live resize in
  both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)